### PR TITLE
feat: add GFM extensions with privacy-first design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,41 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dev-debug.log
+# Dependency directories
+node_modules/
+# Environment variables
+.env
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+
+# Task Master
+.taskmaster/
+
+# Claude Code
+CLAUDE.md
+CLAUDE.local.md
+.claude/
+
+# Editor/IDE specific
+.cursor/
+.serena/
+.specstory/
+
+# Environment
+.env
+.env.example

--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ A native SwiftUI Markdown renderer with LaTeX equation support.
 - **LaTeX equations** rendered natively via SwiftMath
   - Inline math: `$...$`
   - Display math: `$$...$$`
+- **Task lists** with checkbox rendering (`- [ ]` and `- [x]`)
+- **Clickable links** with in-app browser (iOS) or system browser (macOS)
+- **Remote image loading** using AsyncImage
+- **Syntax highlighting** for 13+ languages
+- **Mermaid diagrams** via embedded WKWebView
 - **Theming system** with built-in themes (default, gitHub, compact)
+- **Privacy-first** - network features disabled by default
 - **Cross-platform** support for iOS 16+ and macOS 13+
-- **Pure SwiftUI** - no WebViews or JavaScript
+- **Pure SwiftUI** - minimal WebView usage (only for Mermaid)
 
 ## Supported Markdown Elements
 
@@ -28,13 +34,15 @@ A native SwiftUI Markdown renderer with LaTeX equation support.
 | Italic | `*text*` or `_text_` | Supported |
 | Strikethrough | `~~text~~` | Supported |
 | Inline code | `` `code` `` | Supported |
-| Code blocks | ` ``` ` fenced blocks | Supported |
+| Code blocks | ` ``` ` fenced blocks | Supported (with syntax highlighting) |
 | Block quotes | `> quote` | Supported |
-| Ordered lists | `1. item` | Supported |
-| Unordered lists | `- item` or `* item` | Supported |
+| Ordered lists | `1. item` | Supported (with nesting) |
+| Unordered lists | `- item` or `* item` | Supported (with nesting) |
+| Task lists | `- [ ]` and `- [x]` | Supported |
 | Tables | GFM pipe tables | Supported |
-| Links | `[text](url)` | Styled (not clickable) |
-| Images | `![alt](url)` | Alt text only |
+| Links | `[text](url)` | Opt-in (.links feature) |
+| Images | `![alt](url)` | Opt-in (.images feature) |
+| Mermaid diagrams | ` ```mermaid ` | Opt-in (.mermaid feature) |
 | Thematic breaks | `---` or `***` | Supported |
 | Inline LaTeX | `$E=mc^2$` | Supported |
 | Display LaTeX | `$$...$$` | Supported |
@@ -129,6 +137,89 @@ MarkdownView(content)
     .markdownTheme(customTheme)
 ```
 
+## Feature Flags
+
+For privacy, network-dependent features are disabled by default. Enable them using the `.markdownFeatures()` modifier:
+
+```swift
+// Enable clickable links
+MarkdownView(content)
+    .markdownFeatures(.links)
+
+// Enable multiple features
+MarkdownView(content)
+    .markdownFeatures([.links, .images, .syntaxHighlighting])
+
+// Enable all features
+MarkdownView(content)
+    .markdownFeatures(.all)
+```
+
+### Available Features
+
+| Feature | Description | Network Required |
+|---------|-------------|------------------|
+| `.links` | Makes links tappable. iOS opens in SFSafariViewController, macOS opens in default browser | Optional |
+| `.images` | Loads and displays remote images using AsyncImage | Yes |
+| `.syntaxHighlighting` | Colorizes code blocks based on language | No |
+| `.mermaid` | Renders Mermaid diagrams using WKWebView | Yes (CDN) |
+
+### Custom Link Handler
+
+Override the default link behavior:
+
+```swift
+MarkdownView(content)
+    .markdownFeatures(.links)
+    .onLinkTap { url in
+        // Custom handling
+        print("Tapped: \(url)")
+    }
+```
+
+### Syntax Highlighting
+
+When `.syntaxHighlighting` is enabled, code blocks with language specifiers are colorized:
+
+```swift
+MarkdownView("""
+    ```swift
+    let greeting = "Hello, World!"
+    print(greeting)
+    ```
+""")
+.markdownFeatures(.syntaxHighlighting)
+```
+
+Supported languages: Swift, Python, JavaScript, TypeScript, Java, C, C++, Go, Rust, Ruby, Kotlin, PHP, C#.
+
+Customize syntax colors via the theme:
+
+```swift
+var theme = MarkdownTheme.default
+theme.syntaxColors.keyword = .purple
+theme.syntaxColors.string = .red
+theme.syntaxColors.comment = .gray
+```
+
+### Mermaid Diagrams
+
+When `.mermaid` is enabled, Mermaid code blocks are rendered as diagrams:
+
+```swift
+MarkdownView("""
+    ```mermaid
+    graph TD
+        A[Start] --> B{Decision}
+        B -->|Yes| C[OK]
+        B -->|No| D[Cancel]
+    ```
+""")
+.markdownFeatures(.mermaid)
+```
+
+Supports all Mermaid diagram types: flowcharts, sequence diagrams, class diagrams, state diagrams, Gantt charts, pie charts, and more.
+
 ## LaTeX Support
 
 MarkdownExtendedView uses [SwiftMath](https://github.com/mgriebling/SwiftMath) for native LaTeX rendering.
@@ -173,13 +264,10 @@ Current limitations that may be addressed in future versions:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Clickable links | Not supported | Links are styled but not tappable |
-| Image loading | Not supported | Shows alt text; no remote/local image loading |
-| Syntax highlighting | Not supported | Code blocks render in monospace without coloring |
-| Task lists | Not supported | `- [ ]` checkboxes not rendered |
-| Footnotes | Not supported | `[^1]` syntax not processed |
-| Nested lists | Partial | Deep nesting may have alignment issues |
-| Autolinks | Not verified | Raw URLs may not auto-link |
+| Footnotes | Not supported | `[^1]` syntax not processed (requires custom parser) |
+| Reference-style links | Not verified | `[text][ref]` syntax may not work |
+| HTML blocks | Partial | Raw HTML is not rendered |
+| Definition lists | Not supported | Not part of GFM |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A native SwiftUI Markdown renderer with LaTeX equation support.
 | Links | `[text](url)` | Opt-in (.links feature) |
 | Images | `![alt](url)` | Opt-in (.images feature) |
 | Mermaid diagrams | ` ```mermaid ` | Opt-in (.mermaid feature) |
+| Footnotes | `[^1]` and `[^1]: text` | Opt-in (.footnotes feature) |
 | Thematic breaks | `---` or `***` | Supported |
 | Inline LaTeX | `$E=mc^2$` | Supported |
 | Display LaTeX | `$$...$$` | Supported |
@@ -163,6 +164,7 @@ MarkdownView(content)
 | `.images` | Loads and displays remote images using AsyncImage | Yes |
 | `.syntaxHighlighting` | Colorizes code blocks based on language | No |
 | `.mermaid` | Renders Mermaid diagrams using WKWebView | Yes (CDN) |
+| `.footnotes` | Processes footnote syntax (`[^1]`) and renders as superscripts | No |
 
 ### Custom Link Handler
 
@@ -220,6 +222,27 @@ MarkdownView("""
 
 Supports all Mermaid diagram types: flowcharts, sequence diagrams, class diagrams, state diagrams, Gantt charts, pie charts, and more.
 
+### Footnotes
+
+When `.footnotes` is enabled, footnote syntax is processed and rendered:
+
+```swift
+MarkdownView("""
+    This statement needs a citation[^1].
+
+    Another point with a named reference[^note].
+
+    [^1]: Source: Academic Paper, 2024.
+    [^note]: See the documentation for details.
+""")
+.markdownFeatures(.footnotes)
+```
+
+Footnotes are:
+- Rendered as superscript numbers (¹, ², ³...)
+- Collected and displayed in a footnotes section at the end
+- Numbered in order of first appearance in the text
+
 ## LaTeX Support
 
 MarkdownExtendedView uses [SwiftMath](https://github.com/mgriebling/SwiftMath) for native LaTeX rendering.
@@ -264,7 +287,6 @@ Current limitations that may be addressed in future versions:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Footnotes | Not supported | `[^1]` syntax not processed (requires custom parser) |
 | Reference-style links | Not verified | `[text][ref]` syntax may not work |
 | HTML blocks | Partial | Raw HTML is not rendered |
 | Definition lists | Not supported | Not part of GFM |

--- a/Sources/MarkdownExtendedView/Configuration/Features.swift
+++ b/Sources/MarkdownExtendedView/Configuration/Features.swift
@@ -123,3 +123,49 @@ public extension EnvironmentValues {
         set { self[MarkdownLinkHandlerKey.self] = newValue }
     }
 }
+
+// MARK: - View Modifiers
+
+public extension View {
+
+    /// Enables specific Markdown features for this view hierarchy.
+    ///
+    /// By default, all opt-in features are disabled. Use this modifier to
+    /// enable features like clickable links or image loading.
+    ///
+    /// ```swift
+    /// // Enable links only
+    /// MarkdownView(content)
+    ///     .markdownFeatures(.links)
+    ///
+    /// // Enable multiple features
+    /// MarkdownView(content)
+    ///     .markdownFeatures([.links, .images])
+    /// ```
+    ///
+    /// - Parameter features: The features to enable.
+    /// - Returns: A view with the specified features enabled.
+    func markdownFeatures(_ features: MarkdownFeatures) -> some View {
+        environment(\.markdownFeatures, features)
+    }
+
+    /// Sets a custom handler for link taps in Markdown content.
+    ///
+    /// When a link is tapped and the ``MarkdownFeatures/links`` feature is enabled,
+    /// this handler is called instead of the default behavior (opening in browser).
+    ///
+    /// ```swift
+    /// MarkdownView(content)
+    ///     .markdownFeatures(.links)
+    ///     .onLinkTap { url in
+    ///         // Custom link handling
+    ///         print("User tapped: \(url)")
+    ///     }
+    /// ```
+    ///
+    /// - Parameter handler: A closure that receives the tapped URL.
+    /// - Returns: A view with the custom link handler set.
+    func onLinkTap(_ handler: @escaping (URL) -> Void) -> some View {
+        environment(\.markdownLinkHandler, handler)
+    }
+}

--- a/Sources/MarkdownExtendedView/Configuration/Features.swift
+++ b/Sources/MarkdownExtendedView/Configuration/Features.swift
@@ -5,6 +5,7 @@
 // Licensed under MIT License
 
 import Foundation
+import SwiftUI
 
 /// Feature flags for enabling opt-in Markdown capabilities.
 ///
@@ -74,4 +75,51 @@ public struct MarkdownFeatures: OptionSet, Sendable {
     ///
     /// Enables links, images, and mermaid diagram rendering.
     public static let all: MarkdownFeatures = [.links, .images, .mermaid]
+}
+
+// MARK: - Environment Keys
+
+/// Environment key for enabled Markdown features.
+private struct MarkdownFeaturesKey: EnvironmentKey {
+    static let defaultValue: MarkdownFeatures = .none
+}
+
+/// Environment key for custom link tap handler.
+private struct MarkdownLinkHandlerKey: EnvironmentKey {
+    static let defaultValue: ((URL) -> Void)? = nil
+}
+
+public extension EnvironmentValues {
+
+    /// The enabled Markdown features for ``MarkdownView`` instances.
+    ///
+    /// Set this value using the ``SwiftUI/View/markdownFeatures(_:)`` modifier:
+    ///
+    /// ```swift
+    /// MarkdownView(content)
+    ///     .markdownFeatures([.links, .images])
+    /// ```
+    ///
+    /// The features propagate through the view hierarchy.
+    var markdownFeatures: MarkdownFeatures {
+        get { self[MarkdownFeaturesKey.self] }
+        set { self[MarkdownFeaturesKey.self] = newValue }
+    }
+
+    /// A custom handler for link taps in ``MarkdownView``.
+    ///
+    /// When set, this handler is called instead of the default link behavior.
+    /// Use the ``SwiftUI/View/onLinkTap(_:)`` modifier to set this:
+    ///
+    /// ```swift
+    /// MarkdownView(content)
+    ///     .markdownFeatures(.links)
+    ///     .onLinkTap { url in
+    ///         // Custom handling
+    ///     }
+    /// ```
+    var markdownLinkHandler: ((URL) -> Void)? {
+        get { self[MarkdownLinkHandlerKey.self] }
+        set { self[MarkdownLinkHandlerKey.self] = newValue }
+    }
 }

--- a/Sources/MarkdownExtendedView/Configuration/Features.swift
+++ b/Sources/MarkdownExtendedView/Configuration/Features.swift
@@ -64,6 +64,13 @@ public struct MarkdownFeatures: OptionSet, Sendable {
     /// using a WKWebView. This requires loading the Mermaid.js library.
     public static let mermaid = MarkdownFeatures(rawValue: 1 << 2)
 
+    /// Enable syntax highlighting for code blocks.
+    ///
+    /// When enabled, code blocks with language specifiers (e.g., ```swift)
+    /// are rendered with syntax highlighting for keywords, strings, comments,
+    /// and other language constructs.
+    public static let syntaxHighlighting = MarkdownFeatures(rawValue: 1 << 3)
+
     // MARK: - Convenience
 
     /// No features enabled (default).
@@ -73,8 +80,8 @@ public struct MarkdownFeatures: OptionSet, Sendable {
 
     /// All features enabled.
     ///
-    /// Enables links, images, and mermaid diagram rendering.
-    public static let all: MarkdownFeatures = [.links, .images, .mermaid]
+    /// Enables links, images, mermaid diagram rendering, and syntax highlighting.
+    public static let all: MarkdownFeatures = [.links, .images, .mermaid, .syntaxHighlighting]
 }
 
 // MARK: - Environment Keys

--- a/Sources/MarkdownExtendedView/Configuration/Features.swift
+++ b/Sources/MarkdownExtendedView/Configuration/Features.swift
@@ -71,6 +71,13 @@ public struct MarkdownFeatures: OptionSet, Sendable {
     /// and other language constructs.
     public static let syntaxHighlighting = MarkdownFeatures(rawValue: 1 << 3)
 
+    /// Enable footnote processing.
+    ///
+    /// When enabled, footnote syntax (`[^1]` and `[^1]: definition`) is
+    /// processed and rendered as numbered superscripts with a footnotes
+    /// section at the end of the document.
+    public static let footnotes = MarkdownFeatures(rawValue: 1 << 4)
+
     // MARK: - Convenience
 
     /// No features enabled (default).
@@ -80,8 +87,8 @@ public struct MarkdownFeatures: OptionSet, Sendable {
 
     /// All features enabled.
     ///
-    /// Enables links, images, mermaid diagram rendering, and syntax highlighting.
-    public static let all: MarkdownFeatures = [.links, .images, .mermaid, .syntaxHighlighting]
+    /// Enables links, images, mermaid diagrams, syntax highlighting, and footnotes.
+    public static let all: MarkdownFeatures = [.links, .images, .mermaid, .syntaxHighlighting, .footnotes]
 }
 
 // MARK: - Environment Keys

--- a/Sources/MarkdownExtendedView/Configuration/Features.swift
+++ b/Sources/MarkdownExtendedView/Configuration/Features.swift
@@ -1,0 +1,77 @@
+// Features.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import Foundation
+
+/// Feature flags for enabling opt-in Markdown capabilities.
+///
+/// By default, all features that require network access or external resources
+/// are disabled. Use the ``SwiftUI/View/markdownFeatures(_:)`` modifier to
+/// enable specific features.
+///
+/// ## Example
+///
+/// ```swift
+/// // Enable clickable links
+/// MarkdownView(content)
+///     .markdownFeatures(.links)
+///
+/// // Enable multiple features
+/// MarkdownView(content)
+///     .markdownFeatures([.links, .images])
+/// ```
+///
+/// ## Privacy
+///
+/// Features like ``links`` and ``images`` are disabled by default to respect
+/// user privacy. When enabled:
+/// - **Links**: On iOS, opens URLs in an in-app browser (SFSafariViewController).
+///   On macOS, opens in the default browser.
+/// - **Images**: Loads images from remote URLs using AsyncImage.
+/// - **Mermaid**: Renders diagrams using a WebView.
+public struct MarkdownFeatures: OptionSet, Sendable {
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    // MARK: - Feature Flags
+
+    /// Enable clickable links.
+    ///
+    /// When enabled, `[text](url)` links become tappable:
+    /// - **iOS**: Opens in SFSafariViewController (in-app browser)
+    /// - **macOS**: Opens in the default browser
+    ///
+    /// Use ``SwiftUI/View/onLinkTap(_:)`` for custom link handling.
+    public static let links = MarkdownFeatures(rawValue: 1 << 0)
+
+    /// Enable image loading from URLs.
+    ///
+    /// When enabled, `![alt](url)` images are loaded using AsyncImage.
+    /// Supports both remote (https://) and local (file://) URLs.
+    public static let images = MarkdownFeatures(rawValue: 1 << 1)
+
+    /// Enable Mermaid diagram rendering.
+    ///
+    /// When enabled, ```mermaid code blocks are rendered as diagrams
+    /// using a WKWebView. This requires loading the Mermaid.js library.
+    public static let mermaid = MarkdownFeatures(rawValue: 1 << 2)
+
+    // MARK: - Convenience
+
+    /// No features enabled (default).
+    ///
+    /// All opt-in features are disabled. This is the default state.
+    public static let none: MarkdownFeatures = []
+
+    /// All features enabled.
+    ///
+    /// Enables links, images, and mermaid diagram rendering.
+    public static let all: MarkdownFeatures = [.links, .images, .mermaid]
+}

--- a/Sources/MarkdownExtendedView/Extensions/Checkbox+Helpers.swift
+++ b/Sources/MarkdownExtendedView/Extensions/Checkbox+Helpers.swift
@@ -1,0 +1,32 @@
+// Checkbox+Helpers.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import Markdown
+
+/// Extension to add convenience properties to the Checkbox type from swift-markdown.
+public extension Checkbox {
+
+    /// Returns `true` for both checked and unchecked checkboxes.
+    ///
+    /// This is useful when you need to determine if a list item is a task list item
+    /// vs a regular list item (which would have `checkbox == nil`).
+    var isTask: Bool {
+        switch self {
+        case .checked, .unchecked:
+            return true
+        }
+    }
+
+    /// Returns `true` if the checkbox is in the checked state.
+    var isChecked: Bool {
+        switch self {
+        case .checked:
+            return true
+        case .unchecked:
+            return false
+        }
+    }
+}

--- a/Sources/MarkdownExtendedView/MarkdownView.swift
+++ b/Sources/MarkdownExtendedView/MarkdownView.swift
@@ -47,6 +47,7 @@ public struct MarkdownView: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.markdownTheme) private var theme
+    @Environment(\.markdownFeatures) private var features
 
     // MARK: - Initialization
 
@@ -83,8 +84,17 @@ public struct MarkdownView: View {
     // MARK: - Parsing
 
     private func parseMarkdown(_ content: String) -> Document {
+        var processedContent = content
+
+        // Pre-process footnotes if enabled
+        if features.contains(.footnotes) {
+            let footnoteResult = FootnotePreprocessor().process(processedContent)
+            processedContent = footnoteResult.processedMarkdown
+        }
+
         // Pre-process content to handle LaTeX blocks before markdown parsing
-        let processedContent = LaTeXPreprocessor.process(content)
+        processedContent = LaTeXPreprocessor.process(processedContent)
+
         return Document(parsing: processedContent, options: [.parseBlockDirectives, .parseSymbolLinks])
     }
 }

--- a/Sources/MarkdownExtendedView/Preprocessing/FootnotePreprocessor.swift
+++ b/Sources/MarkdownExtendedView/Preprocessing/FootnotePreprocessor.swift
@@ -1,0 +1,318 @@
+// FootnotePreprocessor.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import Foundation
+
+/// Result of footnote preprocessing.
+public struct FootnoteProcessingResult: Sendable {
+
+    /// The processed markdown with footnotes transformed.
+    public let processedMarkdown: String
+
+    /// Whether any footnotes were found.
+    public let hasFootnotes: Bool
+
+    /// The number of footnotes found.
+    public let footnoteCount: Int
+
+    /// Map of footnote identifiers to their content.
+    public let footnotes: [String: String]
+
+    /// Ordered list of footnote identifiers as they appear in text.
+    public let orderedReferences: [String]
+}
+
+/// Pre-processes markdown to handle footnote syntax.
+///
+/// Since swift-markdown doesn't expose footnote nodes from cmark-gfm,
+/// this preprocessor handles footnote syntax by:
+/// 1. Extracting footnote definitions (`[^id]: content`)
+/// 2. Replacing inline references (`[^id]`) with superscript numbers
+/// 3. Appending a footnotes section at the end
+///
+/// ## Usage
+///
+/// ```swift
+/// let preprocessor = FootnotePreprocessor()
+/// let result = preprocessor.process(markdownString)
+/// // Use result.processedMarkdown with swift-markdown parser
+/// ```
+public struct FootnotePreprocessor: Sendable {
+
+    /// Superscript digits for footnote numbers.
+    private static let superscriptDigits: [Character: Character] = [
+        "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴",
+        "5": "⁵", "6": "⁶", "7": "⁷", "8": "⁸", "9": "⁹"
+    ]
+
+    public init() {}
+
+    /// Processes markdown text and handles footnote syntax.
+    ///
+    /// - Parameter markdown: The original markdown text.
+    /// - Returns: Processing result with transformed markdown and footnote data.
+    public func process(_ markdown: String) -> FootnoteProcessingResult {
+        // Step 1: Find all code blocks to exclude them from processing
+        let codeBlockRanges = findCodeBlockRanges(in: markdown)
+
+        // Step 2: Extract footnote definitions
+        let (definitionStripped, definitions) = extractDefinitions(
+            from: markdown,
+            excludingRanges: codeBlockRanges
+        )
+
+        // Step 3: Find and replace inline references
+        let (processed, orderedRefs) = replaceReferences(
+            in: definitionStripped,
+            definitions: definitions,
+            excludingRanges: findCodeBlockRanges(in: definitionStripped)
+        )
+
+        // Step 4: If we have footnotes, append the footnotes section
+        guard !orderedRefs.isEmpty else {
+            return FootnoteProcessingResult(
+                processedMarkdown: markdown,
+                hasFootnotes: false,
+                footnoteCount: 0,
+                footnotes: definitions,
+                orderedReferences: []
+            )
+        }
+
+        let footnotesSection = buildFootnotesSection(
+            orderedRefs: orderedRefs,
+            definitions: definitions
+        )
+
+        let finalMarkdown = processed.trimmingCharacters(in: .whitespacesAndNewlines)
+            + "\n\n" + footnotesSection
+
+        return FootnoteProcessingResult(
+            processedMarkdown: finalMarkdown,
+            hasFootnotes: true,
+            footnoteCount: orderedRefs.count,
+            footnotes: definitions,
+            orderedReferences: orderedRefs
+        )
+    }
+
+    // MARK: - Private Methods
+
+    /// Finds ranges of code blocks to exclude from footnote processing.
+    private func findCodeBlockRanges(in text: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+
+        // Match fenced code blocks (``` or ~~~)
+        let fencedPattern = #"(?m)^(`{3,}|~{3,}).*$[\s\S]*?^\1\s*$"#
+        if let regex = try? NSRegularExpression(pattern: fencedPattern, options: []) {
+            let nsRange = NSRange(text.startIndex..., in: text)
+            let matches = regex.matches(in: text, options: [], range: nsRange)
+            for match in matches {
+                if let range = Range(match.range, in: text) {
+                    ranges.append(range)
+                }
+            }
+        }
+
+        // Match indented code blocks (4 spaces or tab at start of line)
+        let indentedPattern = #"(?m)^(?: {4}|\t).+$"#
+        if let regex = try? NSRegularExpression(pattern: indentedPattern, options: []) {
+            let nsRange = NSRange(text.startIndex..., in: text)
+            let matches = regex.matches(in: text, options: [], range: nsRange)
+            for match in matches {
+                if let range = Range(match.range, in: text) {
+                    ranges.append(range)
+                }
+            }
+        }
+
+        return ranges
+    }
+
+    /// Checks if an index is within any of the excluded ranges.
+    private func isInExcludedRange(_ index: String.Index, ranges: [Range<String.Index>]) -> Bool {
+        for range in ranges {
+            if range.contains(index) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Extracts footnote definitions from markdown.
+    private func extractDefinitions(
+        from markdown: String,
+        excludingRanges: [Range<String.Index>]
+    ) -> (strippedMarkdown: String, definitions: [String: String]) {
+        var definitions: [String: String] = [:]
+        var strippedLines: [String] = []
+        let lines = markdown.components(separatedBy: "\n")
+
+        // Pattern for footnote definition: [^id]: content
+        let definitionPattern = #"^\[\^([^\]]+)\]:\s*(.*)$"#
+        let definitionRegex = try? NSRegularExpression(pattern: definitionPattern, options: [])
+
+        var currentFootnoteId: String?
+        var currentFootnoteContent: [String] = []
+
+        for (lineIndex, line) in lines.enumerated() {
+            // Calculate approximate position to check exclusion
+            let lineStart = lines[0..<lineIndex].joined(separator: "\n").count
+            let approximateIndex = markdown.index(
+                markdown.startIndex,
+                offsetBy: min(lineStart, markdown.count - 1),
+                limitedBy: markdown.endIndex
+            ) ?? markdown.startIndex
+
+            // Skip lines in code blocks
+            if isInExcludedRange(approximateIndex, ranges: excludingRanges) {
+                if let id = currentFootnoteId {
+                    definitions[id] = currentFootnoteContent.joined(separator: " ")
+                    currentFootnoteId = nil
+                    currentFootnoteContent = []
+                }
+                strippedLines.append(line)
+                continue
+            }
+
+            // Check for footnote definition start
+            if let regex = definitionRegex,
+               let match = regex.firstMatch(
+                   in: line,
+                   options: [],
+                   range: NSRange(line.startIndex..., in: line)
+               ) {
+                // Save previous footnote if any
+                if let id = currentFootnoteId {
+                    definitions[id] = currentFootnoteContent.joined(separator: " ")
+                }
+
+                // Start new footnote
+                if let idRange = Range(match.range(at: 1), in: line),
+                   let contentRange = Range(match.range(at: 2), in: line) {
+                    currentFootnoteId = String(line[idRange])
+                    currentFootnoteContent = [String(line[contentRange]).trimmingCharacters(in: .whitespaces)]
+                }
+                continue // Don't add definition line to output
+            }
+
+            // Check for continuation of multi-line footnote (indented lines)
+            if currentFootnoteId != nil && (line.hasPrefix("    ") || line.hasPrefix("\t")) {
+                let content = line.trimmingCharacters(in: .whitespaces)
+                if !content.isEmpty {
+                    currentFootnoteContent.append(content)
+                }
+                continue // Don't add continuation line to output
+            }
+
+            // End of footnote if we hit a non-continuation line
+            if let id = currentFootnoteId {
+                definitions[id] = currentFootnoteContent.joined(separator: " ")
+                currentFootnoteId = nil
+                currentFootnoteContent = []
+            }
+
+            strippedLines.append(line)
+        }
+
+        // Handle final footnote
+        if let id = currentFootnoteId {
+            definitions[id] = currentFootnoteContent.joined(separator: " ")
+        }
+
+        return (strippedLines.joined(separator: "\n"), definitions)
+    }
+
+    /// Replaces footnote references with superscript numbers.
+    private func replaceReferences(
+        in markdown: String,
+        definitions: [String: String],
+        excludingRanges: [Range<String.Index>]
+    ) -> (processedMarkdown: String, orderedReferences: [String]) {
+        var orderedRefs: [String] = []
+        var refToNumber: [String: Int] = [:]
+        var result = markdown
+
+        // Pattern for inline footnote reference: [^id]
+        // But NOT followed by : (which would be a definition)
+        let referencePattern = #"\[\^([^\]]+)\](?!:)"#
+        guard let regex = try? NSRegularExpression(pattern: referencePattern, options: []) else {
+            return (markdown, [])
+        }
+
+        // Find all matches first
+        var matches: [(range: Range<String.Index>, id: String)] = []
+        let nsRange = NSRange(result.startIndex..., in: result)
+
+        regex.enumerateMatches(in: result, options: [], range: nsRange) { match, _, _ in
+            guard let match = match,
+                  let fullRange = Range(match.range, in: result),
+                  let idRange = Range(match.range(at: 1), in: result) else {
+                return
+            }
+
+            // Check if this match is in an excluded range
+            if isInExcludedRange(fullRange.lowerBound, ranges: excludingRanges) {
+                return
+            }
+
+            let id = String(result[idRange])
+            matches.append((range: fullRange, id: id))
+        }
+
+        // Process matches in reverse order to maintain string indices
+        for match in matches.reversed() {
+            let id = match.id
+
+            // Assign number if not already assigned
+            if refToNumber[id] == nil {
+                orderedRefs.append(id)
+                refToNumber[id] = orderedRefs.count
+            }
+
+            let number = refToNumber[id]!
+            let superscript = toSuperscript(number)
+
+            result.replaceSubrange(match.range, with: superscript)
+        }
+
+        // Return refs in order of first appearance
+        return (result, orderedRefs)
+    }
+
+    /// Converts a number to superscript string.
+    private func toSuperscript(_ number: Int) -> String {
+        let digits = String(number)
+        var result = ""
+        for char in digits {
+            if let superChar = Self.superscriptDigits[char] {
+                result.append(superChar)
+            } else {
+                result.append(char)
+            }
+        }
+        return result
+    }
+
+    /// Builds the footnotes section to append.
+    private func buildFootnotesSection(
+        orderedRefs: [String],
+        definitions: [String: String]
+    ) -> String {
+        var lines: [String] = []
+        lines.append("---")
+        lines.append("")
+
+        for (index, id) in orderedRefs.enumerated() {
+            let number = index + 1
+            let content = definitions[id] ?? "*[undefined]*"
+            lines.append("\(toSuperscript(number)) \(content)")
+            lines.append("")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -14,12 +14,20 @@ struct MarkdownRenderer: View {
     let theme: MarkdownTheme
     let baseURL: URL?
 
+    @Environment(\.markdownFeatures) private var features
+    @Environment(\.markdownLinkHandler) private var linkHandler
+
     var body: some View {
         VStack(alignment: .leading, spacing: theme.paragraphSpacing) {
             ForEach(Array(document.children.enumerated()), id: \.offset) { _, child in
                 renderBlock(child)
             }
         }
+    }
+
+    /// Whether clickable links are enabled.
+    private var linksEnabled: Bool {
+        features.contains(.links)
     }
 
     // MARK: - Block Rendering
@@ -231,16 +239,107 @@ struct MarkdownRenderer: View {
         inlineText
     }
 
-    /// Builds a Text view from inline children, handling LaTeX segments.
+    /// Builds a Text view from inline children, handling LaTeX segments and links.
     private func buildInlineText(from parent: any Markup) -> some View {
         let plainText = extractPlainText(from: parent)
 
         // Check if text contains LaTeX
         if LaTeXPreprocessor.containsLaTeX(plainText) {
             return AnyView(renderTextWithLaTeX(parent))
-        } else {
-            return AnyView(buildAttributedText(from: parent))
         }
+
+        // Check if links are enabled and content contains links
+        if linksEnabled && containsLinks(parent) {
+            return AnyView(renderTextWithLinks(parent))
+        }
+
+        return AnyView(buildAttributedText(from: parent))
+    }
+
+    /// Checks if the markup contains any Link nodes.
+    private func containsLinks(_ parent: any Markup) -> Bool {
+        for child in parent.children {
+            if child is Markdown.Link { return true }
+            if containsLinks(child) { return true }
+        }
+        return false
+    }
+
+    /// Renders text with clickable links using flow layout.
+    @ViewBuilder
+    private func renderTextWithLinks(_ parent: any Markup) -> some View {
+        FlowLayout(spacing: 0) {
+            ForEach(Array(parent.children.enumerated()), id: \.offset) { _, child in
+                renderInlineElementAsView(child)
+            }
+        }
+    }
+
+    /// Renders an inline element as a View (for use in flow layout with links).
+    @ViewBuilder
+    private func renderInlineElementAsView(_ element: any Markup) -> some View {
+        switch element {
+        case let text as Markdown.Text:
+            SwiftUI.Text(text.string)
+                .font(theme.bodyFont)
+                .foregroundColor(theme.textColor)
+
+        case let strong as Strong:
+            renderStrongAsView(strong)
+
+        case let emphasis as Emphasis:
+            renderEmphasisAsView(emphasis)
+
+        case let link as Markdown.Link:
+            TappableLinkView(
+                link: link,
+                theme: theme,
+                linkHandler: linkHandler,
+                baseURL: baseURL
+            )
+
+        case let code as InlineCode:
+            SwiftUI.Text(code.code)
+                .font(theme.codeFont)
+                .foregroundColor(theme.textColor)
+
+        case _ as SoftBreak:
+            SwiftUI.Text(" ")
+                .font(theme.bodyFont)
+                .foregroundColor(theme.textColor)
+
+        case _ as LineBreak:
+            SwiftUI.Text("\n")
+                .font(theme.bodyFont)
+                .foregroundColor(theme.textColor)
+
+        default:
+            if let plainText = element as? any PlainTextConvertibleMarkup {
+                SwiftUI.Text(plainText.plainText)
+                    .font(theme.bodyFont)
+                    .foregroundColor(theme.textColor)
+            }
+        }
+    }
+
+    /// Helper for rendering Strong in flow layout (simplified to avoid type inference issues).
+    @ViewBuilder
+    private func renderStrongAsView(_ strong: Strong) -> some View {
+        // Simplified: render plain text with bold styling
+        SwiftUI.Text(extractPlainText(from: strong))
+            .bold()
+            .font(theme.bodyFont)
+            .foregroundColor(theme.textColor)
+    }
+
+    /// Helper for rendering Emphasis in flow layout (simplified to avoid type inference issues).
+    @ViewBuilder
+    private func renderEmphasisAsView(_ emphasis: Emphasis) -> some View {
+        // Simplified: render plain text with italic styling
+        SwiftUI.Text(extractPlainText(from: emphasis))
+            .italic()
+            .font(theme.bodyFont)
+            .foregroundColor(theme.textColor)
     }
 
     /// Renders text that may contain inline LaTeX.

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -30,6 +30,11 @@ struct MarkdownRenderer: View {
         features.contains(.links)
     }
 
+    /// Whether syntax highlighting is enabled.
+    private var syntaxHighlightingEnabled: Bool {
+        features.contains(.syntaxHighlighting)
+    }
+
     // MARK: - Block Rendering
 
     private func renderBlock(_ markup: any Markup) -> AnyView {
@@ -93,9 +98,17 @@ struct MarkdownRenderer: View {
     @ViewBuilder
     private func renderCodeBlock(_ codeBlock: CodeBlock) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            Text(codeBlock.code.trimmingCharacters(in: .newlines))
-                .font(theme.codeBlockFont)
-                .foregroundColor(theme.textColor)
+            if syntaxHighlightingEnabled && codeBlock.language != nil {
+                HighlightedCodeView(
+                    code: codeBlock.code,
+                    language: codeBlock.language,
+                    theme: theme
+                )
+            } else {
+                Text(codeBlock.code.trimmingCharacters(in: .newlines))
+                    .font(theme.codeBlockFont)
+                    .foregroundColor(theme.textColor)
+            }
         }
         .padding(theme.codeBlockPadding)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -129,7 +129,11 @@ struct MarkdownRenderer: View {
     private func renderUnorderedList(_ list: UnorderedList) -> some View {
         VStack(alignment: .leading, spacing: theme.listItemSpacing) {
             ForEach(Array(list.listItems.enumerated()), id: \.offset) { _, item in
-                renderListItem(item, bullet: "•")
+                if item.checkbox != nil {
+                    renderTaskListItem(item)
+                } else {
+                    renderListItem(item, bullet: "•")
+                }
             }
         }
     }
@@ -140,6 +144,22 @@ struct MarkdownRenderer: View {
             Text(bullet)
                 .font(theme.bodyFont)
                 .foregroundColor(theme.textColor)
+                .frame(width: 20, alignment: .trailing)
+
+            VStack(alignment: .leading, spacing: theme.listItemSpacing) {
+                ForEach(Array(item.children.enumerated()), id: \.offset) { _, child in
+                    renderBlock(child)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderTaskListItem(_ item: ListItem) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: item.checkbox?.isChecked == true ? "checkmark.square.fill" : "square")
+                .font(theme.bodyFont)
+                .foregroundColor(item.checkbox?.isChecked == true ? theme.linkColor : theme.secondaryTextColor)
                 .frame(width: 20, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: theme.listItemSpacing) {

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -253,7 +253,17 @@ struct MarkdownRenderer: View {
             return AnyView(renderTextWithLinks(parent))
         }
 
+        // Check if images are enabled and content contains images
+        if imagesEnabled && containsImages(parent) {
+            return AnyView(renderTextWithImages(parent))
+        }
+
         return AnyView(buildAttributedText(from: parent))
+    }
+
+    /// Whether image loading is enabled.
+    private var imagesEnabled: Bool {
+        features.contains(.images)
     }
 
     /// Checks if the markup contains any Link nodes.
@@ -263,6 +273,25 @@ struct MarkdownRenderer: View {
             if containsLinks(child) { return true }
         }
         return false
+    }
+
+    /// Checks if the markup contains any Image nodes.
+    private func containsImages(_ parent: any Markup) -> Bool {
+        for child in parent.children {
+            if child is Markdown.Image { return true }
+            if containsImages(child) { return true }
+        }
+        return false
+    }
+
+    /// Renders text with images using flow layout.
+    @ViewBuilder
+    private func renderTextWithImages(_ parent: any Markup) -> some View {
+        FlowLayout(spacing: 0) {
+            ForEach(Array(parent.children.enumerated()), id: \.offset) { _, child in
+                renderInlineElementAsView(child)
+            }
+        }
     }
 
     /// Renders text with clickable links using flow layout.
@@ -312,6 +341,13 @@ struct MarkdownRenderer: View {
             SwiftUI.Text("\n")
                 .font(theme.bodyFont)
                 .foregroundColor(theme.textColor)
+
+        case let image as Markdown.Image:
+            MarkdownImageView(
+                image: image,
+                theme: theme,
+                baseURL: baseURL
+            )
 
         default:
             if let plainText = element as? any PlainTextConvertibleMarkup {

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -35,6 +35,11 @@ struct MarkdownRenderer: View {
         features.contains(.syntaxHighlighting)
     }
 
+    /// Whether Mermaid diagram rendering is enabled.
+    private var mermaidEnabled: Bool {
+        features.contains(.mermaid)
+    }
+
     // MARK: - Block Rendering
 
     private func renderBlock(_ markup: any Markup) -> AnyView {
@@ -97,6 +102,24 @@ struct MarkdownRenderer: View {
 
     @ViewBuilder
     private func renderCodeBlock(_ codeBlock: CodeBlock) -> some View {
+        if codeBlock.language == "mermaid" {
+            renderMermaidBlock(codeBlock)
+        } else {
+            renderRegularCodeBlock(codeBlock)
+        }
+    }
+
+    @ViewBuilder
+    private func renderMermaidBlock(_ codeBlock: CodeBlock) -> some View {
+        if mermaidEnabled {
+            MermaidView(code: codeBlock.code, theme: theme)
+        } else {
+            MermaidPlaceholderView(code: codeBlock.code, theme: theme)
+        }
+    }
+
+    @ViewBuilder
+    private func renderRegularCodeBlock(_ codeBlock: CodeBlock) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             if syntaxHighlightingEnabled && codeBlock.language != nil {
                 HighlightedCodeView(

--- a/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
+++ b/Sources/MarkdownExtendedView/Renderer/MarkdownRenderer.swift
@@ -137,30 +137,40 @@ struct MarkdownRenderer: View {
 
     // MARK: - Lists
 
-    @ViewBuilder
-    private func renderOrderedList(_ list: OrderedList) -> some View {
-        VStack(alignment: .leading, spacing: theme.listItemSpacing) {
-            ForEach(Array(list.listItems.enumerated()), id: \.offset) { index, item in
-                renderListItem(item, bullet: "\(index + Int(list.startIndex)).")
-            }
-        }
+    /// Bullet styles for different nesting levels in unordered lists.
+    private static let bulletStyles = ["•", "◦", "▪", "▸"]
+
+    /// Returns the bullet character for a given nesting depth.
+    private func bulletForDepth(_ depth: Int) -> String {
+        Self.bulletStyles[depth % Self.bulletStyles.count]
     }
 
     @ViewBuilder
-    private func renderUnorderedList(_ list: UnorderedList) -> some View {
+    private func renderOrderedList(_ list: OrderedList, depth: Int = 0) -> some View {
+        VStack(alignment: .leading, spacing: theme.listItemSpacing) {
+            ForEach(Array(list.listItems.enumerated()), id: \.offset) { index, item in
+                renderListItem(item, bullet: "\(index + Int(list.startIndex)).", depth: depth)
+            }
+        }
+        .padding(.leading, depth > 0 ? theme.indentation : 0)
+    }
+
+    @ViewBuilder
+    private func renderUnorderedList(_ list: UnorderedList, depth: Int = 0) -> some View {
         VStack(alignment: .leading, spacing: theme.listItemSpacing) {
             ForEach(Array(list.listItems.enumerated()), id: \.offset) { _, item in
                 if item.checkbox != nil {
-                    renderTaskListItem(item)
+                    renderTaskListItem(item, depth: depth)
                 } else {
-                    renderListItem(item, bullet: "•")
+                    renderListItem(item, bullet: bulletForDepth(depth), depth: depth)
                 }
             }
         }
+        .padding(.leading, depth > 0 ? theme.indentation : 0)
     }
 
     @ViewBuilder
-    private func renderListItem(_ item: ListItem, bullet: String) -> some View {
+    private func renderListItem(_ item: ListItem, bullet: String, depth: Int) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(bullet)
                 .font(theme.bodyFont)
@@ -169,14 +179,14 @@ struct MarkdownRenderer: View {
 
             VStack(alignment: .leading, spacing: theme.listItemSpacing) {
                 ForEach(Array(item.children.enumerated()), id: \.offset) { _, child in
-                    renderBlock(child)
+                    renderListChildBlock(child, depth: depth)
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func renderTaskListItem(_ item: ListItem) -> some View {
+    private func renderTaskListItem(_ item: ListItem, depth: Int) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: item.checkbox?.isChecked == true ? "checkmark.square.fill" : "square")
                 .font(theme.bodyFont)
@@ -185,9 +195,20 @@ struct MarkdownRenderer: View {
 
             VStack(alignment: .leading, spacing: theme.listItemSpacing) {
                 ForEach(Array(item.children.enumerated()), id: \.offset) { _, child in
-                    renderBlock(child)
+                    renderListChildBlock(child, depth: depth)
                 }
             }
+        }
+    }
+
+    /// Renders a child block within a list item, handling nested lists specially.
+    private func renderListChildBlock(_ markup: any Markup, depth: Int) -> AnyView {
+        if let nestedOrdered = markup as? OrderedList {
+            return AnyView(renderOrderedList(nestedOrdered, depth: depth + 1))
+        } else if let nestedUnordered = markup as? UnorderedList {
+            return AnyView(renderUnorderedList(nestedUnordered, depth: depth + 1))
+        } else {
+            return renderBlock(markup)
         }
     }
 

--- a/Sources/MarkdownExtendedView/SyntaxHighlighting/SyntaxHighlighter.swift
+++ b/Sources/MarkdownExtendedView/SyntaxHighlighting/SyntaxHighlighter.swift
@@ -1,0 +1,465 @@
+// SyntaxHighlighter.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import Foundation
+
+/// A token type for syntax highlighting.
+public enum TokenType: Sendable {
+    /// A language keyword (e.g., `let`, `func`, `class`, `if`, `return`).
+    case keyword
+    /// A string literal.
+    case string
+    /// A comment.
+    case comment
+    /// A numeric literal.
+    case number
+    /// A type name.
+    case type
+    /// A function or method name.
+    case function
+    /// Plain text (default).
+    case plain
+}
+
+/// A token representing a highlighted segment of code.
+public struct Token: Sendable {
+    /// The text content of this token.
+    public let text: String
+    /// The type of this token for coloring.
+    public let type: TokenType
+
+    public init(text: String, type: TokenType) {
+        self.text = text
+        self.type = type
+    }
+}
+
+/// A simple syntax highlighter that tokenizes code for common languages.
+///
+/// Supports Swift, Python, JavaScript, TypeScript, Java, C, C++, Go, Rust, Ruby,
+/// and other common languages. Falls back to plain text for unknown languages.
+public struct SyntaxHighlighter: Sendable {
+
+    public init() {}
+
+    /// Tokenizes the given code based on the specified language.
+    ///
+    /// - Parameters:
+    ///   - code: The source code to tokenize.
+    ///   - language: The programming language (e.g., "swift", "python", "javascript").
+    /// - Returns: An array of tokens representing the highlighted code.
+    public func tokenize(_ code: String, language: String?) -> [Token] {
+        guard let language = language?.lowercased() else {
+            return [Token(text: code, type: .plain)]
+        }
+
+        let keywords = Self.keywords(for: language)
+        let commentPatterns = Self.commentPatterns(for: language)
+
+        var tokens: [Token] = []
+        var remaining = code[...]
+        var currentPlain = ""
+
+        while !remaining.isEmpty {
+            // Try to match a comment
+            if let (commentToken, rest) = tryMatchComment(remaining, patterns: commentPatterns) {
+                if !currentPlain.isEmpty {
+                    tokens.append(Token(text: currentPlain, type: .plain))
+                    currentPlain = ""
+                }
+                tokens.append(commentToken)
+                remaining = rest
+                continue
+            }
+
+            // Try to match a string
+            if let (stringToken, rest) = tryMatchString(remaining) {
+                if !currentPlain.isEmpty {
+                    tokens.append(Token(text: currentPlain, type: .plain))
+                    currentPlain = ""
+                }
+                tokens.append(stringToken)
+                remaining = rest
+                continue
+            }
+
+            // Try to match a number
+            if let (numberToken, rest) = tryMatchNumber(remaining) {
+                if !currentPlain.isEmpty {
+                    tokens.append(Token(text: currentPlain, type: .plain))
+                    currentPlain = ""
+                }
+                tokens.append(numberToken)
+                remaining = rest
+                continue
+            }
+
+            // Try to match an identifier (keyword, type, or function)
+            if let (identToken, rest) = tryMatchIdentifier(remaining, keywords: keywords) {
+                if !currentPlain.isEmpty {
+                    tokens.append(Token(text: currentPlain, type: .plain))
+                    currentPlain = ""
+                }
+                tokens.append(identToken)
+                remaining = rest
+                continue
+            }
+
+            // No match, consume one character as plain text
+            currentPlain.append(remaining.removeFirst())
+        }
+
+        if !currentPlain.isEmpty {
+            tokens.append(Token(text: currentPlain, type: .plain))
+        }
+
+        return tokens
+    }
+
+    // MARK: - Comment Matching
+
+    private func tryMatchComment(_ input: Substring, patterns: (line: String?, block: (start: String, end: String)?)) -> (Token, Substring)? {
+        // Try line comment
+        if let linePrefix = patterns.line, input.hasPrefix(linePrefix) {
+            let startIndex = input.startIndex
+            var endIndex = input.endIndex
+            if let newlineIndex = input.firstIndex(of: "\n") {
+                endIndex = input.index(after: newlineIndex)
+            }
+            let comment = String(input[startIndex..<endIndex])
+            return (Token(text: comment, type: .comment), input[endIndex...])
+        }
+
+        // Try block comment
+        if let block = patterns.block, input.hasPrefix(block.start) {
+            let afterStart = input.index(input.startIndex, offsetBy: block.start.count)
+            if let endRange = input[afterStart...].range(of: block.end) {
+                let endIndex = endRange.upperBound
+                let comment = String(input[input.startIndex..<endIndex])
+                return (Token(text: comment, type: .comment), input[endIndex...])
+            } else {
+                // Unclosed block comment - treat rest as comment
+                return (Token(text: String(input), type: .comment), input[input.endIndex...])
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - String Matching
+
+    private func tryMatchString(_ input: Substring) -> (Token, Substring)? {
+        let quoteChars: [Character] = ["\"", "'", "`"]
+        guard let firstChar = input.first, quoteChars.contains(firstChar) else {
+            return nil
+        }
+
+        // Handle triple-quoted strings
+        if input.hasPrefix("\"\"\"") || input.hasPrefix("'''") {
+            let quote = String(input.prefix(3))
+            let afterQuote = input.index(input.startIndex, offsetBy: 3)
+            if let endRange = input[afterQuote...].range(of: quote) {
+                let endIndex = endRange.upperBound
+                let string = String(input[input.startIndex..<endIndex])
+                return (Token(text: string, type: .string), input[endIndex...])
+            }
+        }
+
+        // Single-char quote
+        let quote = firstChar
+        var index = input.index(after: input.startIndex)
+        var escaped = false
+
+        while index < input.endIndex {
+            let char = input[index]
+            if escaped {
+                escaped = false
+            } else if char == "\\" {
+                escaped = true
+            } else if char == quote {
+                let endIndex = input.index(after: index)
+                let string = String(input[input.startIndex..<endIndex])
+                return (Token(text: string, type: .string), input[endIndex...])
+            } else if char == "\n" && quote != "`" {
+                // Unterminated string at newline
+                break
+            }
+            index = input.index(after: index)
+        }
+
+        return nil
+    }
+
+    // MARK: - Number Matching
+
+    private func tryMatchNumber(_ input: Substring) -> (Token, Substring)? {
+        guard let firstChar = input.first else { return nil }
+
+        // Check if it starts with a digit or a dot followed by a digit
+        let startsWithDigit = firstChar.isNumber
+        let startsWithDot = firstChar == "." && input.dropFirst().first?.isNumber == true
+
+        guard startsWithDigit || startsWithDot else { return nil }
+
+        // Don't match if preceded by a letter (part of identifier)
+        // This is handled by identifier matching first
+
+        var index = input.startIndex
+        var hasDecimal = startsWithDot
+        var hasExponent = false
+
+        // Handle hex/octal/binary prefixes
+        if firstChar == "0" && input.count > 1 {
+            let second = input[input.index(after: input.startIndex)]
+            if second == "x" || second == "X" || second == "o" || second == "O" || second == "b" || second == "B" {
+                index = input.index(input.startIndex, offsetBy: 2)
+                while index < input.endIndex {
+                    let char = input[index]
+                    if char.isHexDigit || char == "_" {
+                        index = input.index(after: index)
+                    } else {
+                        break
+                    }
+                }
+                let number = String(input[input.startIndex..<index])
+                return (Token(text: number, type: .number), input[index...])
+            }
+        }
+
+        while index < input.endIndex {
+            let char = input[index]
+            if char.isNumber || char == "_" {
+                index = input.index(after: index)
+            } else if char == "." && !hasDecimal && !hasExponent {
+                // Check if next char is a digit
+                let next = input.index(after: index)
+                if next < input.endIndex && input[next].isNumber {
+                    hasDecimal = true
+                    index = input.index(after: index)
+                } else {
+                    break
+                }
+            } else if (char == "e" || char == "E") && !hasExponent {
+                hasExponent = true
+                index = input.index(after: index)
+                if index < input.endIndex && (input[index] == "+" || input[index] == "-") {
+                    index = input.index(after: index)
+                }
+            } else {
+                break
+            }
+        }
+
+        if index > input.startIndex {
+            let number = String(input[input.startIndex..<index])
+            return (Token(text: number, type: .number), input[index...])
+        }
+
+        return nil
+    }
+
+    // MARK: - Identifier Matching
+
+    private func tryMatchIdentifier(_ input: Substring, keywords: Set<String>) -> (Token, Substring)? {
+        guard let firstChar = input.first else { return nil }
+
+        // Check if starts with letter or underscore
+        guard firstChar.isLetter || firstChar == "_" else { return nil }
+
+        var index = input.index(after: input.startIndex)
+        while index < input.endIndex {
+            let char = input[index]
+            if char.isLetter || char.isNumber || char == "_" {
+                index = input.index(after: index)
+            } else {
+                break
+            }
+        }
+
+        let identifier = String(input[input.startIndex..<index])
+        let rest = input[index...]
+
+        // Determine token type
+        let tokenType: TokenType
+        if keywords.contains(identifier) {
+            tokenType = .keyword
+        } else if identifier.first?.isUppercase == true {
+            tokenType = .type
+        } else if rest.first == "(" {
+            tokenType = .function
+        } else {
+            tokenType = .plain
+        }
+
+        return (Token(text: identifier, type: tokenType), rest)
+    }
+
+    // MARK: - Language Definitions
+
+    private static func keywords(for language: String) -> Set<String> {
+        switch language {
+        case "swift":
+            return swiftKeywords
+        case "python", "py":
+            return pythonKeywords
+        case "javascript", "js":
+            return javascriptKeywords
+        case "typescript", "ts":
+            return typescriptKeywords
+        case "java":
+            return javaKeywords
+        case "c":
+            return cKeywords
+        case "cpp", "c++", "cxx":
+            return cppKeywords
+        case "go", "golang":
+            return goKeywords
+        case "rust", "rs":
+            return rustKeywords
+        case "ruby", "rb":
+            return rubyKeywords
+        case "kotlin", "kt":
+            return kotlinKeywords
+        case "php":
+            return phpKeywords
+        case "csharp", "cs", "c#":
+            return csharpKeywords
+        default:
+            return []
+        }
+    }
+
+    private static func commentPatterns(for language: String) -> (line: String?, block: (start: String, end: String)?) {
+        switch language {
+        case "python", "py", "ruby", "rb":
+            return ("#", nil)
+        case "swift", "java", "javascript", "js", "typescript", "ts", "c", "cpp", "c++", "cxx",
+             "go", "golang", "rust", "rs", "kotlin", "kt", "php", "csharp", "cs", "c#":
+            return ("//", (start: "/*", end: "*/"))
+        default:
+            return ("//", (start: "/*", end: "*/"))
+        }
+    }
+
+    // MARK: - Keyword Sets
+
+    private static let swiftKeywords: Set<String> = [
+        "actor", "any", "as", "associatedtype", "async", "await", "break", "case", "catch", "class",
+        "continue", "default", "defer", "deinit", "do", "else", "enum", "extension", "fallthrough",
+        "false", "fileprivate", "final", "for", "func", "get", "guard", "if", "import", "in", "infix",
+        "init", "inout", "internal", "is", "lazy", "let", "mutating", "nil", "nonisolated", "nonmutating",
+        "open", "operator", "optional", "override", "postfix", "precedencegroup", "prefix", "private",
+        "protocol", "public", "repeat", "required", "rethrows", "return", "self", "Self", "set", "some",
+        "static", "struct", "subscript", "super", "switch", "throw", "throws", "true", "try", "typealias",
+        "unowned", "var", "weak", "where", "while", "willSet", "didSet", "@escaping", "@MainActor",
+        "@Sendable", "@available", "@Published", "@State", "@Binding", "@Environment", "@ViewBuilder"
+    ]
+
+    private static let pythonKeywords: Set<String> = [
+        "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+        "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+        "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+        "with", "yield", "self", "print"
+    ]
+
+    private static let javascriptKeywords: Set<String> = [
+        "async", "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default",
+        "delete", "do", "else", "export", "extends", "false", "finally", "for", "function", "if",
+        "import", "in", "instanceof", "let", "new", "null", "return", "static", "super", "switch",
+        "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield",
+        "console", "require", "module", "exports"
+    ]
+
+    private static let typescriptKeywords: Set<String> = javascriptKeywords.union([
+        "abstract", "any", "as", "boolean", "declare", "enum", "implements", "interface", "keyof",
+        "namespace", "never", "number", "object", "private", "protected", "public", "readonly",
+        "string", "symbol", "type", "unknown"
+    ])
+
+    private static let javaKeywords: Set<String> = [
+        "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+        "continue", "default", "do", "double", "else", "enum", "extends", "false", "final", "finally",
+        "float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long",
+        "native", "new", "null", "package", "private", "protected", "public", "return", "short",
+        "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient",
+        "true", "try", "void", "volatile", "while"
+    ]
+
+    private static let cKeywords: Set<String> = [
+        "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
+        "enum", "extern", "float", "for", "goto", "if", "inline", "int", "long", "register",
+        "restrict", "return", "short", "signed", "sizeof", "static", "struct", "switch", "typedef",
+        "union", "unsigned", "void", "volatile", "while", "_Bool", "_Complex", "_Imaginary",
+        "NULL", "true", "false"
+    ]
+
+    private static let cppKeywords: Set<String> = cKeywords.union([
+        "alignas", "alignof", "and", "and_eq", "asm", "bitand", "bitor", "bool", "catch", "class",
+        "compl", "concept", "consteval", "constexpr", "constinit", "const_cast", "co_await",
+        "co_return", "co_yield", "decltype", "delete", "dynamic_cast", "explicit", "export", "friend",
+        "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or",
+        "or_eq", "private", "protected", "public", "reinterpret_cast", "requires", "static_assert",
+        "static_cast", "template", "this", "thread_local", "throw", "try", "typeid", "typename",
+        "using", "virtual", "wchar_t", "xor", "xor_eq", "override", "final"
+    ])
+
+    private static let goKeywords: Set<String> = [
+        "break", "case", "chan", "const", "continue", "default", "defer", "else", "fallthrough",
+        "for", "func", "go", "goto", "if", "import", "interface", "map", "package", "range",
+        "return", "select", "struct", "switch", "type", "var", "nil", "true", "false", "iota",
+        "append", "cap", "close", "complex", "copy", "delete", "imag", "len", "make", "new",
+        "panic", "print", "println", "real", "recover"
+    ]
+
+    private static let rustKeywords: Set<String> = [
+        "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum",
+        "extern", "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move",
+        "mut", "pub", "ref", "return", "self", "Self", "static", "struct", "super", "trait", "true",
+        "type", "unsafe", "use", "where", "while", "abstract", "become", "box", "do", "final",
+        "macro", "override", "priv", "try", "typeof", "unsized", "virtual", "yield"
+    ]
+
+    private static let rubyKeywords: Set<String> = [
+        "BEGIN", "END", "alias", "and", "begin", "break", "case", "class", "def", "defined?",
+        "do", "else", "elsif", "end", "ensure", "false", "for", "if", "in", "module", "next",
+        "nil", "not", "or", "redo", "rescue", "retry", "return", "self", "super", "then", "true",
+        "undef", "unless", "until", "when", "while", "yield", "require", "puts", "attr_accessor",
+        "attr_reader", "attr_writer", "private", "protected", "public"
+    ]
+
+    private static let kotlinKeywords: Set<String> = [
+        "abstract", "actual", "annotation", "as", "break", "by", "catch", "class", "companion",
+        "const", "constructor", "continue", "crossinline", "data", "do", "else", "enum", "expect",
+        "external", "false", "final", "finally", "for", "fun", "get", "if", "import", "in",
+        "infix", "init", "inline", "inner", "interface", "internal", "is", "lateinit", "noinline",
+        "null", "object", "open", "operator", "out", "override", "package", "private", "protected",
+        "public", "reified", "return", "sealed", "set", "super", "suspend", "tailrec", "this",
+        "throw", "true", "try", "typealias", "val", "var", "vararg", "when", "where", "while"
+    ]
+
+    private static let phpKeywords: Set<String> = [
+        "abstract", "and", "array", "as", "break", "callable", "case", "catch", "class", "clone",
+        "const", "continue", "declare", "default", "do", "echo", "else", "elseif", "empty",
+        "enddeclare", "endfor", "endforeach", "endif", "endswitch", "endwhile", "eval", "exit",
+        "extends", "false", "final", "finally", "fn", "for", "foreach", "function", "global",
+        "goto", "if", "implements", "include", "include_once", "instanceof", "insteadof",
+        "interface", "isset", "list", "match", "namespace", "new", "null", "or", "print", "private",
+        "protected", "public", "readonly", "require", "require_once", "return", "static", "switch",
+        "throw", "trait", "true", "try", "unset", "use", "var", "while", "xor", "yield"
+    ]
+
+    private static let csharpKeywords: Set<String> = [
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "var",
+        "virtual", "void", "volatile", "while", "async", "await", "dynamic", "nameof", "when"
+    ]
+}

--- a/Sources/MarkdownExtendedView/Theme/Theme.swift
+++ b/Sources/MarkdownExtendedView/Theme/Theme.swift
@@ -6,6 +6,69 @@
 
 import SwiftUI
 
+// MARK: - Syntax Colors
+
+/// Colors for syntax highlighting in code blocks.
+///
+/// These colors are used when the ``MarkdownFeatures/syntaxHighlighting`` feature
+/// is enabled to colorize different token types in code blocks.
+public struct SyntaxColors: Sendable {
+
+    /// Color for keywords (e.g., `let`, `func`, `class`, `if`, `return`).
+    public var keyword: Color
+
+    /// Color for string literals (e.g., `"Hello"`).
+    public var string: Color
+
+    /// Color for comments (e.g., `// comment`).
+    public var comment: Color
+
+    /// Color for numbers (e.g., `42`, `3.14`).
+    public var number: Color
+
+    /// Color for type names (e.g., `String`, `Int`, `MyClass`).
+    public var type: Color
+
+    /// Color for function/method names.
+    public var function: Color
+
+    /// Color for plain text (default code color).
+    public var plain: Color
+
+    /// Creates a syntax color palette.
+    public init(
+        keyword: Color = Color(red: 0.61, green: 0.13, blue: 0.58),      // Purple
+        string: Color = Color(red: 0.77, green: 0.1, blue: 0.09),         // Red
+        comment: Color = Color(red: 0.42, green: 0.48, blue: 0.51),       // Gray
+        number: Color = Color(red: 0.11, green: 0.44, blue: 0.72),        // Blue
+        type: Color = Color(red: 0.11, green: 0.44, blue: 0.72),          // Blue
+        function: Color = Color(red: 0.16, green: 0.5, blue: 0.73),       // Teal
+        plain: Color = .primary
+    ) {
+        self.keyword = keyword
+        self.string = string
+        self.comment = comment
+        self.number = number
+        self.type = type
+        self.function = function
+        self.plain = plain
+    }
+
+    /// Default syntax colors matching Xcode's default theme.
+    public static let `default` = SyntaxColors()
+
+    /// GitHub-style syntax colors.
+    public static let gitHub = SyntaxColors(
+        keyword: Color(red: 0.84, green: 0.16, blue: 0.5),                // #d73a49
+        string: Color(red: 0.0, green: 0.37, blue: 0.73),                 // #005cc5
+        comment: Color(red: 0.42, green: 0.48, blue: 0.51),               // #6a737d
+        number: Color(red: 0.0, green: 0.37, blue: 0.73),                 // #005cc5
+        type: Color(red: 0.42, green: 0.22, blue: 0.6),                   // #6f42c1
+        function: Color(red: 0.42, green: 0.22, blue: 0.6),               // #6f42c1
+        plain: Color(red: 0.14, green: 0.16, blue: 0.18)                  // #24292e
+    )
+}
+
 // MARK: - Theme
 
 /// A theme for customizing the appearance of rendered Markdown content.
@@ -94,6 +157,9 @@ public struct MarkdownTheme: Sendable {
     /// Table header background color.
     public var tableHeaderBackgroundColor: Color
 
+    /// Syntax highlighting colors for code blocks.
+    public var syntaxColors: SyntaxColors
+
     // MARK: - Spacing
 
     /// Spacing between paragraphs.
@@ -124,6 +190,7 @@ public struct MarkdownTheme: Sendable {
         blockQuoteBorderColor: Color = Color(white: 0.75),
         tableBorderColor: Color = Color(white: 0.80),
         tableHeaderBackgroundColor: Color = Color(white: 0.90),
+        syntaxColors: SyntaxColors = .default,
         paragraphSpacing: CGFloat = 12,
         listItemSpacing: CGFloat = 4,
         indentation: CGFloat = 20,
@@ -145,6 +212,7 @@ public struct MarkdownTheme: Sendable {
         self.blockQuoteBorderColor = blockQuoteBorderColor
         self.tableBorderColor = tableBorderColor
         self.tableHeaderBackgroundColor = tableHeaderBackgroundColor
+        self.syntaxColors = syntaxColors
         self.paragraphSpacing = paragraphSpacing
         self.listItemSpacing = listItemSpacing
         self.indentation = indentation
@@ -193,6 +261,7 @@ public extension MarkdownTheme {
         codeBlockFont: .system(size: 13, design: .monospaced),
         linkColor: Color(red: 0.0, green: 0.4, blue: 0.8),
         codeBackgroundColor: Color(red: 0.96, green: 0.97, blue: 0.98),
+        syntaxColors: .gitHub,
         paragraphSpacing: 16,
         listItemSpacing: 4,
         indentation: 24,

--- a/Sources/MarkdownExtendedView/Utilities/LinkOpener.swift
+++ b/Sources/MarkdownExtendedView/Utilities/LinkOpener.swift
@@ -1,0 +1,32 @@
+// LinkOpener.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Utility for opening URLs on the current platform.
+enum LinkOpener {
+
+    /// Opens a URL using the system's default handler.
+    ///
+    /// - On iOS: Opens in Safari (external browser)
+    /// - On macOS: Opens in the default browser
+    ///
+    /// - Parameter url: The URL to open.
+    @MainActor
+    static func openInBrowser(_ url: URL) {
+        #if canImport(UIKit)
+        UIApplication.shared.open(url)
+        #elseif canImport(AppKit)
+        NSWorkspace.shared.open(url)
+        #endif
+    }
+}

--- a/Sources/MarkdownExtendedView/Views/HighlightedCodeView.swift
+++ b/Sources/MarkdownExtendedView/Views/HighlightedCodeView.swift
@@ -1,0 +1,83 @@
+// HighlightedCodeView.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import SwiftUI
+
+/// A view that renders syntax-highlighted code.
+///
+/// This view tokenizes code using the ``SyntaxHighlighter`` and renders
+/// each token with the appropriate color from the theme's ``SyntaxColors``.
+struct HighlightedCodeView: View {
+
+    let code: String
+    let language: String?
+    let theme: MarkdownTheme
+
+    private let highlighter = SyntaxHighlighter()
+
+    var body: some View {
+        let tokens = highlighter.tokenize(code.trimmingCharacters(in: .newlines), language: language)
+        let lines = splitIntoLines(tokens)
+
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, lineTokens in
+                lineView(for: lineTokens)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func lineView(for tokens: [Token]) -> some View {
+        if tokens.isEmpty {
+            Text(" ")
+                .font(theme.codeBlockFont)
+        } else {
+            tokens.reduce(SwiftUI.Text("")) { result, token in
+                result + SwiftUI.Text(token.text)
+                    .foregroundColor(color(for: token.type))
+            }
+            .font(theme.codeBlockFont)
+        }
+    }
+
+    private func color(for tokenType: TokenType) -> Color {
+        switch tokenType {
+        case .keyword:
+            return theme.syntaxColors.keyword
+        case .string:
+            return theme.syntaxColors.string
+        case .comment:
+            return theme.syntaxColors.comment
+        case .number:
+            return theme.syntaxColors.number
+        case .type:
+            return theme.syntaxColors.type
+        case .function:
+            return theme.syntaxColors.function
+        case .plain:
+            return theme.syntaxColors.plain
+        }
+    }
+
+    /// Splits tokens into lines, preserving token structure.
+    private func splitIntoLines(_ tokens: [Token]) -> [[Token]] {
+        var lines: [[Token]] = [[]]
+
+        for token in tokens {
+            let parts = token.text.components(separatedBy: "\n")
+            for (index, part) in parts.enumerated() {
+                if index > 0 {
+                    lines.append([])
+                }
+                if !part.isEmpty {
+                    lines[lines.count - 1].append(Token(text: part, type: token.type))
+                }
+            }
+        }
+
+        return lines
+    }
+}

--- a/Sources/MarkdownExtendedView/Views/MarkdownImageView.swift
+++ b/Sources/MarkdownExtendedView/Views/MarkdownImageView.swift
@@ -1,0 +1,87 @@
+// MarkdownImageView.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import SwiftUI
+import Markdown
+
+/// A view that displays an image from a markdown Image node.
+///
+/// When the `.images` feature is enabled, this view loads and displays
+/// images using AsyncImage. When disabled, it shows the alt text.
+struct MarkdownImageView: View {
+
+    let image: Markdown.Image
+    let theme: MarkdownTheme
+    let baseURL: URL?
+
+    @Environment(\.markdownFeatures) private var features
+
+    var body: some View {
+        if features.contains(.images), let url = resolvedURL {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, minHeight: 100)
+
+                case .success(let loadedImage):
+                    loadedImage
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .accessibilityLabel(image.plainText)
+
+                case .failure:
+                    errorPlaceholder
+
+                @unknown default:
+                    errorPlaceholder
+                }
+            }
+        } else {
+            altTextView
+        }
+    }
+
+    /// The alt text fallback when images are disabled or unavailable.
+    private var altTextView: some View {
+        Text("[\(image.plainText)]")
+            .font(theme.bodyFont)
+            .foregroundColor(theme.secondaryTextColor)
+    }
+
+    /// Error placeholder when image fails to load.
+    private var errorPlaceholder: some View {
+        VStack(spacing: 4) {
+            Image(systemName: "photo")
+                .font(.title2)
+                .foregroundColor(theme.secondaryTextColor)
+            if !image.plainText.isEmpty {
+                Text(image.plainText)
+                    .font(theme.bodyFont)
+                    .foregroundColor(theme.secondaryTextColor)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 60)
+        .background(theme.codeBackgroundColor.opacity(0.5))
+        .cornerRadius(8)
+    }
+
+    /// Resolves the image URL from the source string.
+    private var resolvedURL: URL? {
+        guard let source = image.source else { return nil }
+
+        // Try to create URL directly
+        if let url = URL(string: source) {
+            // If it's a relative URL and we have a base URL, resolve it
+            if url.scheme == nil, let base = baseURL {
+                return URL(string: source, relativeTo: base)?.absoluteURL
+            }
+            return url
+        }
+
+        return nil
+    }
+}

--- a/Sources/MarkdownExtendedView/Views/MermaidView.swift
+++ b/Sources/MarkdownExtendedView/Views/MermaidView.swift
@@ -1,0 +1,219 @@
+// MermaidView.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import SwiftUI
+import WebKit
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// A view that renders Mermaid diagrams using a WebView.
+///
+/// When the `.mermaid` feature is enabled, code blocks with language "mermaid"
+/// are rendered using this view, which embeds the Mermaid.js library.
+struct MermaidView: View {
+
+    let code: String
+    let theme: MarkdownTheme
+
+    @State private var height: CGFloat = 200
+
+    var body: some View {
+        MermaidWebView(code: code, height: $height)
+            .frame(height: height)
+            .background(theme.codeBackgroundColor)
+            .cornerRadius(8)
+    }
+}
+
+// MARK: - Platform-Specific WebView
+
+#if canImport(UIKit)
+
+/// UIKit implementation of the Mermaid WebView.
+struct MermaidWebView: UIViewRepresentable {
+
+    let code: String
+    @Binding var height: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.scrollView.isScrollEnabled = false
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let html = generateHTML(for: code)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: MermaidWebView
+
+        init(_ parent: MermaidWebView) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            // Get the content height after rendering
+            webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] result, _ in
+                if let height = result as? CGFloat {
+                    DispatchQueue.main.async {
+                        self?.parent.height = max(height, 100)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#elseif canImport(AppKit)
+
+/// AppKit implementation of the Mermaid WebView.
+struct MermaidWebView: NSViewRepresentable {
+
+    let code: String
+    @Binding var height: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        let html = generateHTML(for: code)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: MermaidWebView
+
+        init(_ parent: MermaidWebView) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            // Get the content height after rendering
+            webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] result, _ in
+                if let height = result as? CGFloat {
+                    DispatchQueue.main.async {
+                        self?.parent.height = max(height, 100)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif
+
+// MARK: - HTML Generation
+
+/// Generates the HTML document for rendering a Mermaid diagram.
+private func generateHTML(for code: String) -> String {
+    // Escape the code for use in HTML/JavaScript
+    let escapedCode = code
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "`", with: "\\`")
+        .replacingOccurrences(of: "$", with: "\\$")
+
+    return """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                display: flex;
+                justify-content: center;
+                align-items: flex-start;
+                padding: 16px;
+                background: transparent;
+            }
+            .mermaid {
+                max-width: 100%;
+            }
+            .mermaid svg {
+                max-width: 100%;
+                height: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="mermaid">
+        \(escapedCode)
+        </div>
+        <script>
+            mermaid.initialize({
+                startOnLoad: true,
+                theme: 'neutral',
+                securityLevel: 'loose',
+                flowchart: {
+                    useMaxWidth: true,
+                    htmlLabels: true
+                }
+            });
+        </script>
+    </body>
+    </html>
+    """
+}
+
+/// A placeholder view shown when mermaid is disabled.
+struct MermaidPlaceholderView: View {
+
+    let code: String
+    let theme: MarkdownTheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "chart.bar.xaxis")
+                    .foregroundColor(theme.secondaryTextColor)
+                Text("Mermaid Diagram")
+                    .font(theme.bodyFont)
+                    .foregroundColor(theme.secondaryTextColor)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code.trimmingCharacters(in: .newlines))
+                    .font(theme.codeBlockFont)
+                    .foregroundColor(theme.textColor)
+            }
+        }
+        .padding(theme.codeBlockPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.codeBackgroundColor)
+        .cornerRadius(8)
+    }
+}

--- a/Sources/MarkdownExtendedView/Views/SafariView.swift
+++ b/Sources/MarkdownExtendedView/Views/SafariView.swift
@@ -1,0 +1,30 @@
+// SafariView.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+#if canImport(UIKit)
+import SwiftUI
+import SafariServices
+
+/// A SwiftUI wrapper for SFSafariViewController to display web content in-app.
+///
+/// This view is used internally by MarkdownView when the `.links` feature is enabled
+/// to open links in an in-app browser rather than switching to Safari.
+struct SafariView: UIViewControllerRepresentable {
+
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let configuration = SFSafariViewController.Configuration()
+        configuration.entersReaderIfAvailable = false
+        let safariViewController = SFSafariViewController(url: url, configuration: configuration)
+        return safariViewController
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+        // No updates needed
+    }
+}
+#endif

--- a/Sources/MarkdownExtendedView/Views/TappableLinkView.swift
+++ b/Sources/MarkdownExtendedView/Views/TappableLinkView.swift
@@ -1,0 +1,126 @@
+// TappableLinkView.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import SwiftUI
+import Markdown
+
+/// A tappable view that renders a markdown link with proper handling.
+///
+/// On iOS, tapping opens the link in an in-app browser (SFSafariViewController).
+/// On macOS, tapping opens the link in the default browser.
+/// A custom handler can be provided to override the default behavior.
+struct TappableLinkView: View {
+
+    let link: Markdown.Link
+    let theme: MarkdownTheme
+    let linkHandler: ((URL) -> Void)?
+    let baseURL: URL?
+    var textTransform: ((SwiftUI.Text) -> SwiftUI.Text)?
+
+    #if canImport(UIKit)
+    @State private var showingSafari = false
+    #endif
+
+    var body: some View {
+        linkText
+            .foregroundColor(theme.linkColor)
+            .underline()
+            .onTapGesture {
+                handleTap()
+            }
+        #if canImport(UIKit)
+            .sheet(isPresented: $showingSafari) {
+                if let url = resolvedURL {
+                    SafariView(url: url)
+                }
+            }
+        #endif
+    }
+
+    /// The text content of the link with optional transform applied.
+    private var linkText: some View {
+        let text = buildLinkText()
+        if let transform = textTransform {
+            return AnyView(transform(text))
+        } else {
+            return AnyView(text)
+        }
+    }
+
+    /// Builds the Text from the link's children.
+    private func buildLinkText() -> SwiftUI.Text {
+        var result = SwiftUI.Text("")
+        for child in link.children {
+            if let textNode = child as? Markdown.Text {
+                result = result + SwiftUI.Text(textNode.string)
+            } else if child is Strong {
+                let inner = extractPlainText(from: child)
+                result = result + SwiftUI.Text(inner).bold()
+            } else if child is Emphasis {
+                let inner = extractPlainText(from: child)
+                result = result + SwiftUI.Text(inner).italic()
+            } else if let code = child as? InlineCode {
+                result = result + SwiftUI.Text(code.code).font(theme.codeFont)
+            } else if let plain = child as? any PlainTextConvertibleMarkup {
+                result = result + SwiftUI.Text(plain.plainText)
+            }
+        }
+        return result.font(theme.bodyFont)
+    }
+
+    /// Extracts plain text from markup.
+    private func extractPlainText(from markup: any Markup) -> String {
+        if let plain = markup as? any PlainTextConvertibleMarkup {
+            return plain.plainText
+        }
+        return markup.children.map { extractPlainText(from: $0) }.joined()
+    }
+
+    /// The resolved URL from the link destination.
+    private var resolvedURL: URL? {
+        guard let destination = link.destination else { return nil }
+
+        // Try to create URL directly
+        if let url = URL(string: destination) {
+            // If it's a relative URL and we have a base URL, resolve it
+            if url.scheme == nil, let base = baseURL {
+                return URL(string: destination, relativeTo: base)?.absoluteURL
+            }
+            return url
+        }
+
+        return nil
+    }
+
+    /// Handles the tap gesture on the link.
+    private func handleTap() {
+        guard let url = resolvedURL else { return }
+
+        // If custom handler is provided, use it
+        if let handler = linkHandler {
+            handler(url)
+            return
+        }
+
+        // Default behavior differs by platform
+        #if canImport(UIKit)
+        // On iOS, show in-app browser for http/https URLs
+        if url.scheme == "http" || url.scheme == "https" {
+            showingSafari = true
+        } else {
+            // For other schemes (mailto:, tel:, etc.), use system handler
+            Task { @MainActor in
+                LinkOpener.openInBrowser(url)
+            }
+        }
+        #elseif canImport(AppKit)
+        // On macOS, open in default browser
+        Task { @MainActor in
+            LinkOpener.openInBrowser(url)
+        }
+        #endif
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/ConfigurationTests.swift
+++ b/Tests/MarkdownExtendedViewTests/ConfigurationTests.swift
@@ -81,4 +81,47 @@ final class ConfigurationTests: XCTestCase {
         let placeholder: AnyView? = nil
         XCTAssertNil(placeholder)
     }
+
+    // MARK: - View Modifier Tests
+
+    func testMarkdownFeaturesModifierExists() {
+        // Verify the markdownFeatures modifier can be called
+        let view = Text("Test")
+        let modifiedView = view.markdownFeatures(.links)
+        // If this compiles, the modifier exists
+        XCTAssertNotNil(modifiedView)
+    }
+
+    func testMarkdownFeaturesModifierWithMultipleFlags() {
+        let view = Text("Test")
+        let modifiedView = view.markdownFeatures([.links, .images])
+        XCTAssertNotNil(modifiedView)
+    }
+
+    func testOnLinkTapModifierExists() {
+        // Verify the onLinkTap modifier can be called
+        let view = Text("Test")
+        let modifiedView = view.onLinkTap { _ in }
+        XCTAssertNotNil(modifiedView)
+    }
+
+    func testModifiersCanBeChained() {
+        // Verify modifiers can be chained together
+        let view = Text("Test")
+        let modifiedView = view
+            .markdownFeatures([.links, .images])
+            .onLinkTap { url in
+                print("Tapped: \(url)")
+            }
+        XCTAssertNotNil(modifiedView)
+    }
+
+    func testMarkdownFeaturesWithTheme() {
+        // Verify features can be combined with theme
+        let view = Text("Test")
+        let modifiedView = view
+            .markdownTheme(.gitHub)
+            .markdownFeatures(.links)
+        XCTAssertNotNil(modifiedView)
+    }
 }

--- a/Tests/MarkdownExtendedViewTests/ConfigurationTests.swift
+++ b/Tests/MarkdownExtendedViewTests/ConfigurationTests.swift
@@ -1,0 +1,84 @@
+// ConfigurationTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import SwiftUI
+@testable import MarkdownExtendedView
+
+final class ConfigurationTests: XCTestCase {
+
+    // MARK: - Environment Default Values
+
+    func testFeaturesDefaultIsNone() {
+        // The default value for markdownFeatures should be .none
+        let defaultFeatures = MarkdownFeatures.none
+        XCTAssertTrue(defaultFeatures.isEmpty)
+    }
+
+    func testLinkHandlerDefaultIsNil() {
+        // The default value for link handler should be nil
+        // We can't directly test EnvironmentValues without a view,
+        // but we can verify the type allows nil
+        let handler: ((URL) -> Void)? = nil
+        XCTAssertNil(handler)
+    }
+
+    // MARK: - LinkHandler Type
+
+    func testLinkHandlerCanStoreCallback() {
+        var callbackInvoked = false
+        var receivedURL: URL?
+
+        let handler: (URL) -> Void = { url in
+            callbackInvoked = true
+            receivedURL = url
+        }
+
+        let testURL = URL(string: "https://example.com")!
+        handler(testURL)
+
+        XCTAssertTrue(callbackInvoked)
+        XCTAssertEqual(receivedURL, testURL)
+    }
+
+    func testLinkHandlerCallbackWithDifferentURLs() {
+        var urls: [URL] = []
+
+        let handler: (URL) -> Void = { url in
+            urls.append(url)
+        }
+
+        let url1 = URL(string: "https://example.com")!
+        let url2 = URL(string: "https://test.com/path")!
+
+        handler(url1)
+        handler(url2)
+
+        XCTAssertEqual(urls.count, 2)
+        XCTAssertEqual(urls[0], url1)
+        XCTAssertEqual(urls[1], url2)
+    }
+
+    // MARK: - Features Contains Check
+
+    func testFeaturesContainsLinks() {
+        let features: MarkdownFeatures = [.links, .images]
+        XCTAssertTrue(features.contains(.links))
+    }
+
+    func testFeaturesDoesNotContainMermaid() {
+        let features: MarkdownFeatures = [.links, .images]
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    // MARK: - ImageHandler Type (for future use)
+
+    func testImagePlaceholderTypeExists() {
+        // Verify we can create an optional AnyView for placeholder
+        let placeholder: AnyView? = nil
+        XCTAssertNil(placeholder)
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/FootnoteTests.swift
+++ b/Tests/MarkdownExtendedViewTests/FootnoteTests.swift
@@ -1,0 +1,192 @@
+// FootnoteTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+@testable import MarkdownExtendedView
+
+final class FootnoteTests: XCTestCase {
+
+    // MARK: - Footnote Detection Tests
+
+    func testDetectsInlineFootnoteReference() {
+        let markdown = "This has a footnote[^1] in the text."
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        XCTAssertTrue(result.hasFootnotes)
+        XCTAssertEqual(result.footnoteCount, 1)
+    }
+
+    func testDetectsFootnoteDefinition() {
+        let markdown = """
+        Text with footnote[^1].
+
+        [^1]: This is the footnote content.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        XCTAssertTrue(result.hasFootnotes)
+        XCTAssertEqual(result.footnoteCount, 1)
+        XCTAssertNotNil(result.footnotes["1"])
+        XCTAssertEqual(result.footnotes["1"], "This is the footnote content.")
+    }
+
+    func testDetectsMultipleFootnotes() {
+        let markdown = """
+        First footnote[^1] and second[^2].
+
+        [^1]: First definition.
+        [^2]: Second definition.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        XCTAssertEqual(result.footnoteCount, 2)
+        XCTAssertEqual(result.footnotes["1"], "First definition.")
+        XCTAssertEqual(result.footnotes["2"], "Second definition.")
+    }
+
+    func testDetectsNamedFootnotes() {
+        let markdown = """
+        Reference to note[^note-name].
+
+        [^note-name]: Named footnote content.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        XCTAssertEqual(result.footnoteCount, 1)
+        XCTAssertNotNil(result.footnotes["note-name"])
+    }
+
+    // MARK: - Footnote Transformation Tests
+
+    func testReplacesFootnoteWithSuperscript() {
+        let markdown = "Text[^1] here."
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // The processed markdown should contain a superscript marker
+        XCTAssertTrue(result.processedMarkdown.contains("¹"))
+    }
+
+    func testAppendsFootnotesSection() {
+        let markdown = """
+        Text with footnote[^1].
+
+        [^1]: The footnote content.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // Should contain a footnotes section
+        XCTAssertTrue(result.processedMarkdown.contains("---"))
+        XCTAssertTrue(result.processedMarkdown.contains("The footnote content"))
+    }
+
+    func testPreservesOriginalContentWithoutFootnotes() {
+        let markdown = "Just regular markdown with **bold** and *italic*."
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        XCTAssertFalse(result.hasFootnotes)
+        XCTAssertEqual(result.processedMarkdown, markdown)
+    }
+
+    // MARK: - Multi-line Footnote Tests
+
+    func testHandlesMultilineFootnote() {
+        let markdown = """
+        Text[^1].
+
+        [^1]: First line of footnote.
+            Second line continues.
+            Third line too.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        let footnoteContent = result.footnotes["1"] ?? ""
+        XCTAssertTrue(footnoteContent.contains("First line"))
+        XCTAssertTrue(footnoteContent.contains("Second line"))
+    }
+
+    // MARK: - Edge Cases
+
+    func testHandlesFootnoteWithoutDefinition() {
+        let markdown = "Reference[^missing] without definition."
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // Should still process but mark as undefined
+        XCTAssertTrue(result.hasFootnotes)
+    }
+
+    func testHandlesDefinitionWithoutReference() {
+        let markdown = """
+        No reference in text.
+
+        [^orphan]: This footnote is never referenced.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // Definition exists but shouldn't appear in rendered footnotes
+        XCTAssertNotNil(result.footnotes["orphan"])
+    }
+
+    func testHandlesFootnoteInCodeBlock() {
+        let markdown = """
+        ```
+        [^1]: This is not a footnote, it's code
+        ```
+
+        Real footnote[^1].
+
+        [^1]: Real definition.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // Should not treat code block content as footnote definition
+        XCTAssertEqual(result.footnoteCount, 1)
+    }
+
+    func testFootnoteNumbering() {
+        let markdown = """
+        First[^a] and second[^b] and third[^c].
+
+        [^a]: Alpha.
+        [^b]: Beta.
+        [^c]: Gamma.
+        """
+        let preprocessor = FootnotePreprocessor()
+        let result = preprocessor.process(markdown)
+
+        // Should number footnotes in order of first appearance
+        XCTAssertTrue(result.processedMarkdown.contains("¹"))
+        XCTAssertTrue(result.processedMarkdown.contains("²"))
+        XCTAssertTrue(result.processedMarkdown.contains("³"))
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func testFootnotesDisabledByDefault() {
+        let features = MarkdownFeatures.none
+        XCTAssertFalse(features.contains(.footnotes))
+    }
+
+    func testFootnotesCanBeEnabled() {
+        let features: MarkdownFeatures = .footnotes
+        XCTAssertTrue(features.contains(.footnotes))
+    }
+
+    func testFootnotesInAllFeatures() {
+        let features = MarkdownFeatures.all
+        XCTAssertTrue(features.contains(.footnotes))
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/ImageTests.swift
+++ b/Tests/MarkdownExtendedViewTests/ImageTests.swift
@@ -1,0 +1,166 @@
+// ImageTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class ImageTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsImage() {
+        let markdown = "![Alt text](https://example.com/image.png)"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        guard let image = paragraph.child(at: 0) as? Markdown.Image else {
+            XCTFail("Failed to find image")
+            return
+        }
+
+        XCTAssertEqual(image.source, "https://example.com/image.png")
+        XCTAssertEqual(image.plainText, "Alt text")
+    }
+
+    func testParserDetectsImageWithTitle() {
+        let markdown = "![Alt text](https://example.com/image.png \"Image Title\")"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let image = paragraph.child(at: 0) as? Markdown.Image else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        XCTAssertEqual(image.source, "https://example.com/image.png")
+        XCTAssertEqual(image.title, "Image Title")
+    }
+
+    func testParserDetectsImageWithEmptyAlt() {
+        let markdown = "![](https://example.com/image.png)"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let image = paragraph.child(at: 0) as? Markdown.Image else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        XCTAssertEqual(image.source, "https://example.com/image.png")
+        XCTAssertEqual(image.plainText, "")
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func testImagesFlagDisabledByDefault() {
+        let features = MarkdownFeatures.none
+        XCTAssertFalse(features.contains(.images))
+    }
+
+    func testImagesCanBeEnabled() {
+        let features: MarkdownFeatures = .images
+        XCTAssertTrue(features.contains(.images))
+    }
+
+    func testImagesInAllFeatures() {
+        let features = MarkdownFeatures.all
+        XCTAssertTrue(features.contains(.images))
+    }
+
+    // MARK: - URL Validation Tests
+
+    func testValidImageURL() {
+        let urlString = "https://example.com/image.png"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "https")
+        XCTAssertTrue(url?.pathExtension == "png")
+    }
+
+    func testLocalFileURL() {
+        let urlString = "file:///path/to/image.png"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "file")
+    }
+
+    func testRelativeImagePath() {
+        let urlString = "images/photo.jpg"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertNil(url?.scheme)
+    }
+
+    // MARK: - Multiple Images Tests
+
+    func testMultipleImagesInDocument() {
+        let markdown = """
+        ![First](https://example.com/1.png)
+
+        ![Second](https://example.com/2.png)
+        """
+        let document = Document(parsing: markdown)
+
+        var imageCount = 0
+        for child in document.children {
+            if let paragraph = child as? Paragraph {
+                for pChild in paragraph.children {
+                    if pChild is Markdown.Image {
+                        imageCount += 1
+                    }
+                }
+            }
+        }
+
+        XCTAssertEqual(imageCount, 2)
+    }
+
+    // MARK: - Image in Context Tests
+
+    func testImageInParagraph() {
+        let markdown = "Here is an image: ![photo](https://example.com/photo.jpg) in text."
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        var foundImage = false
+        var foundText = false
+        for child in paragraph.children {
+            if child is Markdown.Image { foundImage = true }
+            if child is Markdown.Text { foundText = true }
+        }
+
+        XCTAssertTrue(foundImage, "Should find image")
+        XCTAssertTrue(foundText, "Should find text around image")
+    }
+
+    func testImageInLink() {
+        let markdown = "[![Alt](https://example.com/img.png)](https://example.com)"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let link = paragraph.child(at: 0) as? Markdown.Link else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        var foundImage = false
+        for child in link.children {
+            if child is Markdown.Image { foundImage = true }
+        }
+
+        XCTAssertTrue(foundImage, "Link should contain image")
+        XCTAssertEqual(link.destination, "https://example.com")
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/LinkTests.swift
+++ b/Tests/MarkdownExtendedViewTests/LinkTests.swift
@@ -1,0 +1,205 @@
+// LinkTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class LinkTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsLink() {
+        let markdown = "This is a [link](https://example.com)."
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        // Find the link in children
+        var foundLink = false
+        for child in paragraph.children {
+            if let link = child as? Markdown.Link {
+                foundLink = true
+                XCTAssertEqual(link.destination, "https://example.com")
+                XCTAssertEqual(link.plainText, "link")
+            }
+        }
+        XCTAssertTrue(foundLink, "Should find link in paragraph")
+    }
+
+    func testParserDetectsLinkWithTitle() {
+        let markdown = "[link](https://example.com \"Example Title\")"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        guard let link = paragraph.child(at: 0) as? Markdown.Link else {
+            XCTFail("Failed to find link")
+            return
+        }
+
+        XCTAssertEqual(link.destination, "https://example.com")
+        XCTAssertEqual(link.title, "Example Title")
+    }
+
+    func testParserDetectsAutolink() {
+        let markdown = "<https://example.com>"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        // Autolinks become Link nodes in swift-markdown
+        var foundLink = false
+        for child in paragraph.children {
+            if let link = child as? Markdown.Link {
+                foundLink = true
+                XCTAssertEqual(link.destination, "https://example.com")
+            }
+        }
+        XCTAssertTrue(foundLink, "Should find autolink")
+    }
+
+    func testParserDetectsEmailAutolink() {
+        let markdown = "<test@example.com>"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        // Email autolinks also become Link nodes
+        var foundLink = false
+        for child in paragraph.children {
+            if let link = child as? Markdown.Link {
+                foundLink = true
+                XCTAssertTrue(link.destination?.contains("mailto:") == true || link.destination?.contains("test@example.com") == true)
+            }
+        }
+        XCTAssertTrue(foundLink, "Should find email autolink")
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func testLinksFlagDisabledByDefault() {
+        let features = MarkdownFeatures.none
+        XCTAssertFalse(features.contains(.links))
+    }
+
+    func testLinksCanBeEnabled() {
+        let features: MarkdownFeatures = .links
+        XCTAssertTrue(features.contains(.links))
+    }
+
+    func testLinksInAllFeatures() {
+        let features = MarkdownFeatures.all
+        XCTAssertTrue(features.contains(.links))
+    }
+
+    // MARK: - URL Validation Tests
+
+    func testValidHTTPSURL() {
+        let urlString = "https://example.com"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "https")
+    }
+
+    func testValidHTTPURL() {
+        let urlString = "http://example.com"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "http")
+    }
+
+    func testValidMailtoURL() {
+        let urlString = "mailto:test@example.com"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "mailto")
+    }
+
+    func testRelativeURL() {
+        let urlString = "/path/to/page"
+        let url = URL(string: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertNil(url?.scheme)
+    }
+
+    // MARK: - Link with Formatting Tests
+
+    func testLinkWithBoldText() {
+        let markdown = "[**bold link**](https://example.com)"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let link = paragraph.child(at: 0) as? Markdown.Link else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        XCTAssertEqual(link.destination, "https://example.com")
+        // Check that link contains Strong element
+        var foundStrong = false
+        for child in link.children {
+            if child is Strong { foundStrong = true }
+        }
+        XCTAssertTrue(foundStrong, "Link should contain Strong element")
+    }
+
+    func testLinkWithInlineCode() {
+        let markdown = "[`code link`](https://example.com)"
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let link = paragraph.child(at: 0) as? Markdown.Link else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        XCTAssertEqual(link.destination, "https://example.com")
+        // Check that link contains InlineCode element
+        var foundCode = false
+        for child in link.children {
+            if child is InlineCode { foundCode = true }
+        }
+        XCTAssertTrue(foundCode, "Link should contain InlineCode element")
+    }
+
+    // MARK: - Multiple Links Tests
+
+    func testMultipleLinksInParagraph() {
+        let markdown = "Visit [Google](https://google.com) or [Apple](https://apple.com)."
+        let document = Document(parsing: markdown)
+
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Failed to parse paragraph")
+            return
+        }
+
+        var linkCount = 0
+        var destinations: [String] = []
+        for child in paragraph.children {
+            if let link = child as? Markdown.Link, let dest = link.destination {
+                linkCount += 1
+                destinations.append(dest)
+            }
+        }
+
+        XCTAssertEqual(linkCount, 2)
+        XCTAssertTrue(destinations.contains("https://google.com"))
+        XCTAssertTrue(destinations.contains("https://apple.com"))
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/MarkdownFeaturesTests.swift
+++ b/Tests/MarkdownExtendedViewTests/MarkdownFeaturesTests.swift
@@ -1,0 +1,100 @@
+// MarkdownFeaturesTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+@testable import MarkdownExtendedView
+
+final class MarkdownFeaturesTests: XCTestCase {
+
+    // MARK: - Individual Flags
+
+    func testLinksFlag() {
+        let features: MarkdownFeatures = .links
+        XCTAssertTrue(features.contains(.links))
+        XCTAssertFalse(features.contains(.images))
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    func testImagesFlag() {
+        let features: MarkdownFeatures = .images
+        XCTAssertFalse(features.contains(.links))
+        XCTAssertTrue(features.contains(.images))
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    func testMermaidFlag() {
+        let features: MarkdownFeatures = .mermaid
+        XCTAssertFalse(features.contains(.links))
+        XCTAssertFalse(features.contains(.images))
+        XCTAssertTrue(features.contains(.mermaid))
+    }
+
+    // MARK: - Combined Flags
+
+    func testCombinedFlags() {
+        let features: MarkdownFeatures = [.links, .images]
+        XCTAssertTrue(features.contains(.links))
+        XCTAssertTrue(features.contains(.images))
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    func testUnionOfFlags() {
+        let features1: MarkdownFeatures = .links
+        let features2: MarkdownFeatures = .images
+        let combined = features1.union(features2)
+        XCTAssertTrue(combined.contains(.links))
+        XCTAssertTrue(combined.contains(.images))
+    }
+
+    func testIntersectionOfFlags() {
+        let features1: MarkdownFeatures = [.links, .images]
+        let features2: MarkdownFeatures = [.images, .mermaid]
+        let intersection = features1.intersection(features2)
+        XCTAssertFalse(intersection.contains(.links))
+        XCTAssertTrue(intersection.contains(.images))
+        XCTAssertFalse(intersection.contains(.mermaid))
+    }
+
+    // MARK: - None and All Constants
+
+    func testNoneConstant() {
+        let features: MarkdownFeatures = .none
+        XCTAssertTrue(features.isEmpty)
+        XCTAssertFalse(features.contains(.links))
+        XCTAssertFalse(features.contains(.images))
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    func testAllConstant() {
+        let features: MarkdownFeatures = .all
+        XCTAssertTrue(features.contains(.links))
+        XCTAssertTrue(features.contains(.images))
+        XCTAssertTrue(features.contains(.mermaid))
+    }
+
+    // MARK: - Equality
+
+    func testEquality() {
+        let features1: MarkdownFeatures = [.links, .images]
+        let features2: MarkdownFeatures = [.links, .images]
+        XCTAssertEqual(features1, features2)
+    }
+
+    func testInequality() {
+        let features1: MarkdownFeatures = [.links, .images]
+        let features2: MarkdownFeatures = [.links, .mermaid]
+        XCTAssertNotEqual(features1, features2)
+    }
+
+    // MARK: - Raw Value
+
+    func testRawValueRoundTrip() {
+        let original: MarkdownFeatures = [.links, .mermaid]
+        let rawValue = original.rawValue
+        let restored = MarkdownFeatures(rawValue: rawValue)
+        XCTAssertEqual(original, restored)
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/MermaidTests.swift
+++ b/Tests/MarkdownExtendedViewTests/MermaidTests.swift
@@ -1,0 +1,232 @@
+// MermaidTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class MermaidTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsMermaidCodeBlock() {
+        let markdown = """
+        ```mermaid
+        graph TD
+            A --> B
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+    }
+
+    func testParserDetectsFlowchartDiagram() {
+        let markdown = """
+        ```mermaid
+        flowchart LR
+            A[Start] --> B{Decision}
+            B -->|Yes| C[OK]
+            B -->|No| D[Cancel]
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("flowchart"))
+    }
+
+    func testParserDetectsSequenceDiagram() {
+        let markdown = """
+        ```mermaid
+        sequenceDiagram
+            Alice->>John: Hello John
+            John-->>Alice: Hi Alice
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("sequenceDiagram"))
+    }
+
+    func testParserDetectsClassDiagram() {
+        let markdown = """
+        ```mermaid
+        classDiagram
+            Animal <|-- Dog
+            Animal : +int age
+            Dog : +bark()
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("classDiagram"))
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func testMermaidFlagDisabledByDefault() {
+        let features = MarkdownFeatures.none
+        XCTAssertFalse(features.contains(.mermaid))
+    }
+
+    func testMermaidCanBeEnabled() {
+        let features: MarkdownFeatures = .mermaid
+        XCTAssertTrue(features.contains(.mermaid))
+    }
+
+    func testMermaidInAllFeatures() {
+        let features = MarkdownFeatures.all
+        XCTAssertTrue(features.contains(.mermaid))
+    }
+
+    // MARK: - Helper Function Tests
+
+    func testIsMermaidCodeBlock() {
+        let mermaidMarkdown = """
+        ```mermaid
+        graph TD
+            A --> B
+        ```
+        """
+        let mermaidDoc = Document(parsing: mermaidMarkdown)
+        guard let mermaidBlock = mermaidDoc.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse mermaid block")
+            return
+        }
+        XCTAssertEqual(mermaidBlock.language, "mermaid")
+
+        let swiftMarkdown = """
+        ```swift
+        let x = 5
+        ```
+        """
+        let swiftDoc = Document(parsing: swiftMarkdown)
+        guard let swiftBlock = swiftDoc.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse swift block")
+            return
+        }
+        XCTAssertEqual(swiftBlock.language, "swift")
+        XCTAssertNotEqual(swiftBlock.language, "mermaid")
+    }
+
+    // MARK: - Multiple Diagrams Tests
+
+    func testMultipleMermaidDiagrams() {
+        let markdown = """
+        # First Diagram
+
+        ```mermaid
+        graph TD
+            A --> B
+        ```
+
+        # Second Diagram
+
+        ```mermaid
+        sequenceDiagram
+            A->>B: Message
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        var mermaidCount = 0
+        for child in document.children {
+            if let codeBlock = child as? CodeBlock,
+               codeBlock.language == "mermaid" {
+                mermaidCount += 1
+            }
+        }
+
+        XCTAssertEqual(mermaidCount, 2)
+    }
+
+    // MARK: - Complex Diagram Tests
+
+    func testPieDiagram() {
+        let markdown = """
+        ```mermaid
+        pie title Pets adopted by families
+            "Dogs" : 386
+            "Cats" : 85
+            "Rats" : 15
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("pie"))
+    }
+
+    func testGanttDiagram() {
+        let markdown = """
+        ```mermaid
+        gantt
+            title A Gantt Diagram
+            dateFormat YYYY-MM-DD
+            section Section
+            A task :a1, 2024-01-01, 30d
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("gantt"))
+    }
+
+    func testStateDiagram() {
+        let markdown = """
+        ```mermaid
+        stateDiagram-v2
+            [*] --> Still
+            Still --> [*]
+            Still --> Moving
+            Moving --> Still
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "mermaid")
+        XCTAssertTrue(codeBlock.code.contains("stateDiagram"))
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/NestedListTests.swift
+++ b/Tests/MarkdownExtendedViewTests/NestedListTests.swift
@@ -1,0 +1,284 @@
+// NestedListTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class NestedListTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsNestedUnorderedList() {
+        let markdown = """
+        - Item 1
+          - Nested item
+          - Another nested
+        - Item 2
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse top-level list")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        XCTAssertEqual(items.count, 2)
+
+        // First item should have a nested list
+        let firstItem = items[0]
+        var hasNestedList = false
+        for child in firstItem.children {
+            if child is UnorderedList {
+                hasNestedList = true
+            }
+        }
+        XCTAssertTrue(hasNestedList, "First item should contain a nested list")
+    }
+
+    func testParserDetectsNestedOrderedList() {
+        let markdown = """
+        1. First
+           1. Nested first
+           2. Nested second
+        2. Second
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? OrderedList else {
+            XCTFail("Failed to parse top-level ordered list")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        XCTAssertEqual(items.count, 2)
+
+        // First item should have a nested ordered list
+        let firstItem = items[0]
+        var hasNestedOrderedList = false
+        for child in firstItem.children {
+            if child is OrderedList {
+                hasNestedOrderedList = true
+            }
+        }
+        XCTAssertTrue(hasNestedOrderedList, "First item should contain a nested ordered list")
+    }
+
+    func testParserDetectsMixedNestedLists() {
+        let markdown = """
+        - Unordered
+          1. Ordered inside
+          2. Another ordered
+        - Another unordered
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse top-level list")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        XCTAssertEqual(items.count, 2)
+
+        // First item should have a nested ordered list
+        let firstItem = items[0]
+        var hasNestedOrderedList = false
+        for child in firstItem.children {
+            if child is OrderedList {
+                hasNestedOrderedList = true
+            }
+        }
+        XCTAssertTrue(hasNestedOrderedList, "First item should contain a nested ordered list")
+    }
+
+    func testParserDetectsDeeplyNestedLists() {
+        let markdown = """
+        - Level 1
+          - Level 2
+            - Level 3
+              - Level 4
+        """
+        let document = Document(parsing: markdown)
+
+        guard let level1List = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse level 1 list")
+            return
+        }
+
+        let level1Items = Array(level1List.listItems)
+        guard let level1Item = level1Items.first else {
+            XCTFail("No items in level 1 list")
+            return
+        }
+
+        // Navigate to find level 2 list
+        var level2List: UnorderedList?
+        for child in level1Item.children {
+            if let list = child as? UnorderedList {
+                level2List = list
+            }
+        }
+        XCTAssertNotNil(level2List, "Should find level 2 list")
+
+        // Navigate to find level 3 list
+        guard let l2List = level2List else {
+            XCTFail("Level 2 list not found")
+            return
+        }
+        let level2Items = Array(l2List.listItems)
+        guard let level2Item = level2Items.first else {
+            XCTFail("No items in level 2 list")
+            return
+        }
+
+        var level3List: UnorderedList?
+        for child in level2Item.children {
+            if let list = child as? UnorderedList {
+                level3List = list
+            }
+        }
+        XCTAssertNotNil(level3List, "Should find level 3 list")
+
+        // Navigate to find level 4 list
+        guard let l3List = level3List else {
+            XCTFail("Level 3 list not found")
+            return
+        }
+        let level3Items = Array(l3List.listItems)
+        guard let level3Item = level3Items.first else {
+            XCTFail("No items in level 3 list")
+            return
+        }
+
+        var level4List: UnorderedList?
+        for child in level3Item.children {
+            if let list = child as? UnorderedList {
+                level4List = list
+            }
+        }
+        XCTAssertNotNil(level4List, "Should find level 4 list")
+    }
+
+    // MARK: - Nesting Level Helper Tests
+
+    func testNestedListHasDepth() {
+        // Test that we can calculate nesting depth
+        let markdown = """
+        - Item 1
+          - Nested
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        guard let firstItem = items.first else {
+            XCTFail("Failed to get first item")
+            return
+        }
+
+        var nestedList: UnorderedList?
+        for child in firstItem.children {
+            if let list = child as? UnorderedList {
+                nestedList = list
+            }
+        }
+
+        XCTAssertNotNil(nestedList, "Should have nested list")
+        if let nested = nestedList {
+            XCTAssertEqual(Array(nested.listItems).count, 1)
+        }
+    }
+
+    // MARK: - Bullet Style Tests
+
+    func testBulletStylesExist() {
+        // Verify we have different bullet styles
+        let bullets = ["•", "◦", "▪", "▸"]
+        XCTAssertEqual(bullets.count, 4, "Should have 4 bullet styles")
+    }
+
+    // MARK: - List with Content Tests
+
+    func testNestedListWithMultipleParagraphs() {
+        let markdown = """
+        - Item 1
+
+          Continuation paragraph
+
+          - Nested item
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        guard let firstItem = items.first else {
+            XCTFail("Failed to get first item")
+            return
+        }
+
+        // First item should have multiple children (paragraphs and nested list)
+        var childCount = 0
+        for _ in firstItem.children {
+            childCount += 1
+        }
+        XCTAssertGreaterThan(childCount, 1, "Should have multiple children")
+    }
+
+    func testNestedTaskListItems() {
+        let markdown = """
+        - [x] Completed task
+          - [ ] Subtask 1
+          - [x] Subtask 2
+        """
+        let document = Document(parsing: markdown)
+
+        guard let topList = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse")
+            return
+        }
+
+        let items = Array(topList.listItems)
+        guard let firstItem = items.first else {
+            XCTFail("Failed to get first item")
+            return
+        }
+
+        // First item should be a checked task
+        XCTAssertNotNil(firstItem.checkbox, "Should have checkbox")
+        XCTAssertTrue(firstItem.checkbox?.isChecked == true, "Should be checked")
+
+        // Find nested list
+        var nestedList: UnorderedList?
+        for child in firstItem.children {
+            if let list = child as? UnorderedList {
+                nestedList = list
+            }
+        }
+
+        XCTAssertNotNil(nestedList, "Should have nested list")
+
+        if let nested = nestedList {
+            let nestedItems = Array(nested.listItems)
+            XCTAssertEqual(nestedItems.count, 2)
+
+            // Check nested task items
+            XCTAssertNotNil(nestedItems[0].checkbox, "First nested should be task")
+            XCTAssertFalse(nestedItems[0].checkbox?.isChecked == true, "First nested should be unchecked")
+            XCTAssertNotNil(nestedItems[1].checkbox, "Second nested should be task")
+            XCTAssertTrue(nestedItems[1].checkbox?.isChecked == true, "Second nested should be checked")
+        }
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/SyntaxHighlightingTests.swift
+++ b/Tests/MarkdownExtendedViewTests/SyntaxHighlightingTests.swift
@@ -1,0 +1,212 @@
+// SyntaxHighlightingTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class SyntaxHighlightingTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsCodeBlockWithLanguage() {
+        let markdown = """
+        ```swift
+        let x = 5
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "swift")
+        XCTAssertEqual(codeBlock.code.trimmingCharacters(in: .whitespacesAndNewlines), "let x = 5")
+    }
+
+    func testParserDetectsCodeBlockWithoutLanguage() {
+        let markdown = """
+        ```
+        plain code
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertNil(codeBlock.language)
+    }
+
+    func testParserDetectsCodeBlockWithPython() {
+        let markdown = """
+        ```python
+        def hello():
+            print("Hello")
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "python")
+    }
+
+    func testParserDetectsCodeBlockWithJavaScript() {
+        let markdown = """
+        ```javascript
+        function hello() {
+            console.log("Hello");
+        }
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "javascript")
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func testSyntaxHighlightingFlagDisabledByDefault() {
+        let features = MarkdownFeatures.none
+        XCTAssertFalse(features.contains(.syntaxHighlighting))
+    }
+
+    func testSyntaxHighlightingCanBeEnabled() {
+        let features: MarkdownFeatures = .syntaxHighlighting
+        XCTAssertTrue(features.contains(.syntaxHighlighting))
+    }
+
+    func testSyntaxHighlightingInAllFeatures() {
+        let features = MarkdownFeatures.all
+        XCTAssertTrue(features.contains(.syntaxHighlighting))
+    }
+
+    // MARK: - Highlighter Tests
+
+    func testSyntaxHighlighterExists() {
+        let highlighter = SyntaxHighlighter()
+        XCTAssertNotNil(highlighter)
+    }
+
+    func testHighlightSwiftKeywords() {
+        let highlighter = SyntaxHighlighter()
+        let code = "let x = 5"
+        let tokens = highlighter.tokenize(code, language: "swift")
+
+        // Should contain at least a keyword token for "let"
+        let hasKeyword = tokens.contains { $0.type == .keyword }
+        XCTAssertTrue(hasKeyword, "Should detect 'let' as keyword")
+    }
+
+    func testHighlightSwiftStrings() {
+        let highlighter = SyntaxHighlighter()
+        let code = "let message = \"Hello\""
+        let tokens = highlighter.tokenize(code, language: "swift")
+
+        let hasString = tokens.contains { $0.type == .string }
+        XCTAssertTrue(hasString, "Should detect string literal")
+    }
+
+    func testHighlightSwiftComments() {
+        let highlighter = SyntaxHighlighter()
+        let code = "// This is a comment"
+        let tokens = highlighter.tokenize(code, language: "swift")
+
+        let hasComment = tokens.contains { $0.type == .comment }
+        XCTAssertTrue(hasComment, "Should detect comment")
+    }
+
+    func testHighlightPythonKeywords() {
+        let highlighter = SyntaxHighlighter()
+        let code = "def hello():"
+        let tokens = highlighter.tokenize(code, language: "python")
+
+        let hasKeyword = tokens.contains { $0.type == .keyword }
+        XCTAssertTrue(hasKeyword, "Should detect 'def' as keyword")
+    }
+
+    func testHighlightJavaScriptKeywords() {
+        let highlighter = SyntaxHighlighter()
+        let code = "function test() { return true; }"
+        let tokens = highlighter.tokenize(code, language: "javascript")
+
+        let hasKeyword = tokens.contains { $0.type == .keyword }
+        XCTAssertTrue(hasKeyword, "Should detect 'function' as keyword")
+    }
+
+    func testUnknownLanguageFallback() {
+        let highlighter = SyntaxHighlighter()
+        let code = "some random code"
+        let tokens = highlighter.tokenize(code, language: "unknown_lang")
+
+        // Should return at least plain text token
+        XCTAssertFalse(tokens.isEmpty, "Should return at least one token")
+    }
+
+    // MARK: - Color Theme Tests
+
+    func testDefaultSyntaxColorsExist() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColors)
+    }
+
+    func testSyntaxColorsHaveKeywordColor() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColors.keyword)
+    }
+
+    func testSyntaxColorsHaveStringColor() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColors.string)
+    }
+
+    func testSyntaxColorsHaveCommentColor() {
+        let theme = MarkdownTheme.default
+        XCTAssertNotNil(theme.syntaxColors.comment)
+    }
+
+    func testGitHubThemeHasSyntaxColors() {
+        let theme = MarkdownTheme.gitHub
+        XCTAssertNotNil(theme.syntaxColors)
+        XCTAssertNotNil(theme.syntaxColors.keyword)
+    }
+
+    // MARK: - Multiline Code Tests
+
+    func testMultilineCodeBlock() {
+        let markdown = """
+        ```swift
+        struct Person {
+            let name: String
+            let age: Int
+        }
+        ```
+        """
+        let document = Document(parsing: markdown)
+
+        guard let codeBlock = document.child(at: 0) as? CodeBlock else {
+            XCTFail("Failed to parse code block")
+            return
+        }
+
+        XCTAssertEqual(codeBlock.language, "swift")
+        XCTAssertTrue(codeBlock.code.contains("struct"))
+        XCTAssertTrue(codeBlock.code.contains("let name"))
+    }
+}

--- a/Tests/MarkdownExtendedViewTests/TaskListTests.swift
+++ b/Tests/MarkdownExtendedViewTests/TaskListTests.swift
@@ -1,0 +1,208 @@
+// TaskListTests.swift
+// MarkdownExtendedView
+//
+// Copyright (c) 2025 Christian C. Berclaz
+// Licensed under MIT License
+
+import XCTest
+import Markdown
+@testable import MarkdownExtendedView
+
+final class TaskListTests: XCTestCase {
+
+    // MARK: - Parser Detection Tests
+
+    func testParserDetectsUncheckedTaskListItem() {
+        let markdown = "- [ ] Unchecked task"
+        let document = Document(parsing: markdown)
+
+        // Navigate to the list item
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertNotNil(listItem.checkbox)
+        XCTAssertEqual(listItem.checkbox, .unchecked)
+    }
+
+    func testParserDetectsCheckedTaskListItem() {
+        let markdown = "- [x] Checked task"
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertNotNil(listItem.checkbox)
+        XCTAssertEqual(listItem.checkbox, .checked)
+    }
+
+    func testParserDetectsUppercaseCheckedTaskListItem() {
+        let markdown = "- [X] Checked task with uppercase X"
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertNotNil(listItem.checkbox)
+        XCTAssertEqual(listItem.checkbox, .checked)
+    }
+
+    func testRegularListItemHasNoCheckbox() {
+        let markdown = "- Regular item"
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertNil(listItem.checkbox)
+    }
+
+    func testMixedTaskAndRegularListItems() {
+        let markdown = """
+        - [ ] Unchecked task
+        - [x] Checked task
+        - Regular item
+        """
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+
+        let items = Array(list.listItems)
+        XCTAssertEqual(items.count, 3)
+
+        XCTAssertEqual(items[0].checkbox, .unchecked)
+        XCTAssertEqual(items[1].checkbox, .checked)
+        XCTAssertNil(items[2].checkbox)
+    }
+
+    // MARK: - Checkbox Helper Tests
+
+    func testCheckboxIsTask() {
+        XCTAssertTrue(Checkbox.checked.isTask)
+        XCTAssertTrue(Checkbox.unchecked.isTask)
+    }
+
+    func testCheckboxIsChecked() {
+        XCTAssertTrue(Checkbox.checked.isChecked)
+        XCTAssertFalse(Checkbox.unchecked.isChecked)
+    }
+
+    // MARK: - TaskListItemView Tests
+
+    func testTaskListItemViewExists() {
+        // Verify TaskListItemView can be instantiated
+        // The actual rendering is visual, so we just verify initialization
+        let markdown = "- [x] Test task"
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertNotNil(listItem.checkbox)
+    }
+
+    // MARK: - Complex Task List Tests
+
+    func testNestedTaskListItems() {
+        let markdown = """
+        - [ ] Parent task
+          - [x] Nested completed task
+          - [ ] Nested incomplete task
+        """
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse unordered list")
+            return
+        }
+
+        let listItems = Array(list.listItems)
+        guard let parentItem = listItems.first else {
+            XCTFail("Failed to get parent item")
+            return
+        }
+
+        XCTAssertEqual(parentItem.checkbox, .unchecked)
+
+        // Find nested list
+        var foundNestedList = false
+        for child in parentItem.children {
+            if let nestedList = child as? UnorderedList {
+                foundNestedList = true
+                let nestedItems = Array(nestedList.listItems)
+                XCTAssertEqual(nestedItems.count, 2)
+                XCTAssertEqual(nestedItems[0].checkbox, .checked)
+                XCTAssertEqual(nestedItems[1].checkbox, .unchecked)
+            }
+        }
+        XCTAssertTrue(foundNestedList, "Should find nested list")
+    }
+
+    func testTaskListWithFormattedContent() {
+        let markdown = "- [x] Task with **bold** and *italic* text"
+        let document = Document(parsing: markdown)
+
+        guard let list = document.child(at: 0) as? UnorderedList else {
+            XCTFail("Failed to parse")
+            return
+        }
+        let listItems = Array(list.listItems)
+        guard let listItem = listItems.first else {
+            XCTFail("Failed to get list item")
+            return
+        }
+
+        XCTAssertEqual(listItem.checkbox, .checked)
+        // Verify the paragraph content exists with formatting
+        guard let paragraph = listItem.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph in list item")
+            return
+        }
+        // The paragraph should have children including Strong and Emphasis
+        var foundStrong = false
+        var foundEmphasis = false
+        for child in paragraph.children {
+            if child is Strong { foundStrong = true }
+            if child is Emphasis { foundEmphasis = true }
+        }
+        XCTAssertTrue(foundStrong, "Should find Strong element for **bold**")
+        XCTAssertTrue(foundEmphasis, "Should find Emphasis element for *italic*")
+    }
+}


### PR DESCRIPTION
[38;2;127;132;156m   1[0m [38;2;205;214;244m## Summary[0m
[38;2;127;132;156m   2[0m 
[38;2;127;132;156m   3[0m [38;2;205;214;244m- **Feature Flags System**: Privacy-first opt-in architecture using `MarkdownFeatures` OptionSet and SwiftUI environment values[0m
[38;2;127;132;156m   4[0m [38;2;205;214;244m- **Task Lists**: Checkbox rendering for `- [ ]` and `- [x]` syntax with SF Symbols[0m
[38;2;127;132;156m   5[0m [38;2;205;214;244m- **Clickable Links**: In-app browser (SFSafariViewController) on iOS, system browser on macOS, with custom handler support[0m
[38;2;127;132;156m   6[0m [38;2;205;214;244m- **Remote Images**: AsyncImage-based loading with loading states and error placeholders[0m
[38;2;127;132;156m   7[0m [38;2;205;214;244m- **Syntax Highlighting**: Tokenization-based colorization for 13+ languages with customizable `SyntaxColors`[0m
[38;2;127;132;156m   8[0m [38;2;205;214;244m- **Nested Lists**: Improved depth tracking with rotating bullet styles (•, ◦, ▪, ▸)[0m
[38;2;127;132;156m   9[0m [38;2;205;214;244m- **Mermaid Diagrams**: WKWebView rendering with Mermaid.js CDN support[0m
[38;2;127;132;156m  10[0m [38;2;205;214;244m- **Footnotes**: Pre-processor for `[^1]` syntax with superscript rendering[0m
[38;2;127;132;156m  11[0m 
[38;2;127;132;156m  12[0m [38;2;205;214;244mAll network-dependent features are disabled by default and must be explicitly enabled via `.markdownFeatures()` modifier.[0m
[38;2;127;132;156m  13[0m 
[38;2;127;132;156m  14[0m [38;2;205;214;244m## Test plan[0m
[38;2;127;132;156m  15[0m 
[38;2;127;132;156m  16[0m [38;2;205;214;244m- [x] All 116 tests pass (`swift test`)[0m
[38;2;127;132;156m  17[0m [38;2;205;214;244m- [x] Build succeeds on both iOS and macOS targets (`swift build`)[0m
[38;2;127;132;156m  18[0m [38;2;205;214;244m- [x] Feature flags correctly gate network features[0m
[38;2;127;132;156m  19[0m [38;2;205;214;244m- [x] Links open in SFSafariViewController on iOS[0m
[38;2;127;132;156m  20[0m [38;2;205;214;244m- [x] Syntax highlighting colorizes code blocks when enabled[0m
[38;2;127;132;156m  21[0m [38;2;205;214;244m- [x] Mermaid diagrams render when enabled, show placeholder when disabled[0m
[38;2;127;132;156m  22[0m [38;2;205;214;244m- [x] Nested lists display with correct indentation and bullet styles[0m
[38;2;127;132;156m  23[0m [38;2;205;214;244m- [x] Footnotes processed into superscripts with footnotes section[0m
[38;2;127;132;156m  24[0m 
[38;2;127;132;156m  25[0m [38;2;205;214;244m🤖 Generated with [Claude Code](https://claude.com/claude-code)[0m